### PR TITLE
Improve build troubleshooting docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# llama.kotlin Project Instructions
+
+This file provides guidance for future Codex agents working on the Kotlin port of `llama.cpp`.
+It summarizes the current project state and lists recommended next steps. Before starting new work, read `KOTLIN_PORT_CHECKLIST.md` in the repository root for a detailed roadmap.
+
+## Project Overview
+- The repository is a work‐in‐progress port of `llama.cpp` to Kotlin/Native.
+- Kotlin sources live under `src/nativeMain/kotlin/ai/solace/llamakotlin`.
+- The original C/C++ sources remain under `src` while porting progresses.
+- Design notes and porting progress are documented in:
+  - `KOTLIN_PORT_CHECKLIST.md`
+  - `KOTLIN_PORT_STATUS.md`
+  - `GGML_COMPUTE_OPS_DESIGN.md`
+  - `TENSOR_OPERATIONS_DESIGN.md`
+
+## Coding Guidelines
+- Use idiomatic Kotlin style with descriptive names and KDoc comments.
+- Keep code modular—separate tensor creation logic from compute kernels.
+- Prefer immutable data structures where practical.
+- Document placeholders or incomplete implementations with `TODO` comments.
+
+## Build and Test
+- The project uses Gradle. Build and run tests with `./gradlew build`.
+- Network access may be required to download dependencies; configure as needed.
+- If Gradle fails with a `PKIX path building failed` SSL error, install Java and Gradle via SDKMAN:
+  ```bash
+  curl -s "https://get.sdkman.io" | bash
+  source "$HOME/.sdkman/bin/sdkman-init.sh"
+  sdk install java 17.0.9-tem
+  sdk install gradle 8.13
+  ```
+  Alternatively set `GRADLE_OPTS="-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts"` to use the system certificate store.
+- Unit tests should be placed under `src/nativeTest/kotlin`.
+- C++ tests under `tests` are not required for the Kotlin port.
+
+## Recommended Next Steps
+1. **Finish Tensor Operations**
+   - Implement computation functions in `GGMLComputeOps.kt` as described in `GGML_COMPUTE_OPS_DESIGN.md`.
+   - Expand support for additional tensor types (F16, I8, I16, I64, quantized types).
+   - Optimize operations using SIMD and multithreading where possible.
+
+2. **Computation Graph Enhancements**
+   - Extend `GGMLGraph.kt` with automatic differentiation support.
+   - Add graph optimization passes for redundant operation removal.
+
+3. **CPU Backend Implementation**
+   - Create CPU-specific execution paths for tensor operations.
+   - Investigate Kotlin/Native interop with C for performance‑critical sections.
+   - Begin integrating multi-threading support.
+
+4. **Quantization Support**
+   - Implement 1.5‑bit through 8‑bit quantization formats.
+   - Add quantized operation implementations and conversion utilities.
+
+5. **Testing Infrastructure**
+   - Add unit tests covering tensor creation, basic math ops and graph execution.
+   - Provide sample models or fixtures for integration tests.
+
+6. **Documentation Updates**
+   - Keep `KOTLIN_PORT_STATUS.md` and `KOTLIN_PORT_CHECKLIST.md` up to date.
+   - Document new modules and APIs in the `/docs` folder.
+
+Follow this guide when extending the Kotlin port. Keep commits focused and include
+relevant tests whenever possible.

--- a/setup_java_env.sh
+++ b/setup_java_env.sh
@@ -35,6 +35,12 @@ export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:/bin/java::")
 echo "export JAVA_HOME=$JAVA_HOME" >> /etc/profile.d/java_env.sh
 echo "Java installation completed. JAVA_HOME set to $JAVA_HOME"
 
+# Optionally install Java with SDKMAN to avoid SSL issues
+if command -v sdk >/dev/null 2>&1; then
+    echo "Installing Java 17 using sdkman..."
+    yes | sdk install java 17.0.9-tem || true
+fi
+
 # Extract Gradle version from wrapper properties
 GRADLE_WRAPPER_PROPERTIES="gradle/wrapper/gradle-wrapper.properties"
 if [ -f "$GRADLE_WRAPPER_PROPERTIES" ]; then
@@ -55,8 +61,18 @@ mv /opt/gradle/gradle-${GRADLE_VERSION} /opt/gradle/latest
 ln -s /opt/gradle/latest/bin/gradle /usr/bin/gradle
 rm /tmp/gradle.zip
 
+# Optionally install Gradle with SDKMAN if SSL errors occur
+if command -v sdk >/dev/null 2>&1; then
+    echo "Installing Gradle $GRADLE_VERSION using sdkman..."
+    yes | sdk install gradle ${GRADLE_VERSION} || true
+fi
+
 # Verify Gradle installation
 gradle --version
+
+# Use system certificate store to avoid Gradle SSL handshake issues
+export GRADLE_OPTS="-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts"
+echo "export GRADLE_OPTS=$GRADLE_OPTS" >> /etc/profile.d/gradle_env.sh
 # Set up GRADLE_HOME
 export GRADLE_HOME=/opt/gradle/latest
 echo "export GRADLE_HOME=$GRADLE_HOME" >> /etc/profile.d/gradle_env.sh


### PR DESCRIPTION
## Summary
- mention the checklist in the instructions
- explain how to fix Gradle SSL errors using SDKMAN or GRADLE_OPTS
- update setup script with optional SDKMAN steps and certificate settings

## Testing
- `./gradlew --version` *(fails: SSLHandshakeException PKIX path building failed)*
- `./gradlew build` *(fails: PKIX path building failed)*

------
https://chatgpt.com/codex/tasks/task_e_68448d4270688333860e9028a9117cf5