### PR TITLE
Implement Q8_0 dequantization and data accessors

### DIFF
--- a/KOTLIN_PORT_CHECKLIST.md
+++ b/KOTLIN_PORT_CHECKLIST.md
@@ -75,7 +75,12 @@ This checklist is based on the current state of the Kotlin Native port of llama.
   - [ ] Implement 4-bit integer quantization
   - [ ] Implement 5-bit integer quantization
   - [ ] Implement 6-bit integer quantization
-  - [ ] Implement 8-bit integer quantization
+  - [~] Implement 8-bit integer quantization (Q8_0 focused)
+    - [x] Defined Q8_0 block structure (F16 scale + 32xI8 weights, type.byteSize = 34).
+    - [x] Implemented data accessors for Q8_0 blocks (`getQ8_0BlockScale`, `getQ8_0Weight`).
+    - [x] Implemented Q8_0 to F32 dequantization in `dequantizeTensor`.
+    - [ ] Implement Q8_0 quantization (F32 to Q8_0) in `quantizeTensor`.
+    - [ ] Implement optimized Q8_0 dot product routines (e.g., for MatMul with F32).
   - [ ] Implement quantized operations
 
 ## Phase 3: CPU Backend Implementation


### PR DESCRIPTION
This commit introduces initial support for the Q8_0 quantized data type, focusing on its structure definition, data access, and dequantization to F32.

Key changes:
1.  **`GGMLTypes.kt`:**
    *   Defined `internal const val QK8_0 = 32` for the Q8_0 block size.
    *   Updated `GGMLType.Q8_0`'s `byteSize` to 34 bytes, representing one
        block (1x F16 scale + 32x I8 weights).
    *   Added data accessor methods to `GGMLTensor`:
        *   `getNumBlocks()`: Calculates number of blocks for Q8_0 tensors.
        *   `getQ8_0BlockScale(graphAllocator, blockIndex)`: Reads the F16
            scale for a given block and returns it as Float.
        *   `getQ8_0Weight(graphAllocator, blockIndex, itemIndexInBlock)`:
            Reads a specific I8 quantized weight from a block.
    *   These accessors include appropriate assertions and boundary checks.

2.  **`GGMLComputeOps.kt`:**
    *   Enhanced `dequantizeTensor(graphAllocator, tensor)` to handle
        `GGMLType.Q8_0` input tensors.
    *   The Q8_0 dequantization path iterates through blocks, uses the new
        accessors to get scales and weights, computes the F32 value
        (scale * weight), and populates a new F32 result tensor.
    *   This allows operations like `computeMatMul` (which already use
        `dequantizeTensor` for non-F32 inputs) to implicitly support Q8_0
        inputs by converting them to F32.

3.  **`KOTLIN_PORT_CHECKLIST.md`:**
    *   Updated Phase 2 Quantization Support to mark 8-bit quantization
        (Q8_0 focused) as in-progress.
    *   Detailed completed work (Q8_0 structure, accessors,
        dequantization) and listed pending work (Q8_0 F32->Q8_0
        quantization, optimized Q8_0 routines).

This lays the groundwork for broader Q8_0 support by enabling models using Q8_0 weights to have their data correctly interpreted and dequantized for use in F32 computation paths.