### PR TITLE
Revert "I've implemented the F32 to Q8_0 quantization."

### DIFF
--- a/KOTLIN_PORT_CHECKLIST.md
+++ b/KOTLIN_PORT_CHECKLIST.md
@@ -81,7 +81,7 @@ This checklist is based on the current state of the Kotlin Native port of llama.
     - [x] Defined Q8_0 block structure (F16 scale + 32xI8 weights, type.byteSize = 34).
     - [x] Implemented data accessors for Q8_0 blocks (`getQ8_0BlockScale`, `getQ8_0Weight`).
     - [x] Implemented Q8_0 to F32 dequantization in `dequantizeTensor`.
-    - [x] Implement Q8_0 quantization (F32 to Q8_0) in `quantizeTensor`.
+    - [ ] Implement Q8_0 quantization (F32 to Q8_0) in `quantizeTensor`.
     - [ ] Implement optimized Q8_0 dot product routines (e.g., for MatMul with F32).
   - [ ] Implement quantized operations
 

--- a/src/nativeMain/kotlin/ai/solace/llamakotlin/core/GGMLComputeOps.kt
+++ b/src/nativeMain/kotlin/ai/solace/llamakotlin/core/GGMLComputeOps.kt
@@ -1,9 +1,6 @@
 package ai.solace.llamakotlin.core
 
 import ai.solace.llamakotlin.core.GGMLGraphAllocator // Required for new function signatures
-import kotlin.math.abs
-import kotlin.math.round
-import kotlin.Short.Companion.SIZE_BYTES as SHORT_SIZE_BYTES
 
 /**
  * Kotlin Native port of GGML tensor computation operations.
@@ -230,49 +227,9 @@ private fun quantizeTensor(graphAllocator: GGMLGraphAllocator, tensorF32: GGMLTe
             }
             result.data = resultDataArray
         }
-        GGMLType.Q8_0 -> {
-            val numElements = tensorF32.numElements().toInt()
-            require(numElements % QK8_0 == 0) { "For Q8_0 quantization, total elements ($numElements) must be divisible by QK8_0 ($QK8_0)" }
-            val numBlocks = numElements / QK8_0
-            val q8BlockByteSize = targetType.byteSize.toInt() // Should be 34
-            val q8DataArray = ByteArray(numBlocks * q8BlockByteSize)
-
-            val f32BlockValues = FloatArray(QK8_0)
-            var currentF32ElementIndex = 0
-            var q8ByteArrayWriteOffset = 0
-
-            // This assumes applyNDIter gives elements in a flat, C-contiguous order
-            applyNDIter(tensorF32, numElements) { _, indices ->
-                val itemInBlock = currentF32ElementIndex % QK8_0
-                f32BlockValues[itemInBlock] = tensorF32.getFloat(graphAllocator, *indices)
-
-                if (itemInBlock == QK8_0 - 1) { // Block is full, process it
-                    var amax = 0.0f
-                    for (v in f32BlockValues) { amax = maxOf(amax, abs(v)) }
-
-                    val scaleF32 = if (amax == 0.0f) 1.0f else amax / 127.0f // Max Q8 value is 127 for positive range
-                    val scaleF16Short = floatToHalf(scaleF32)
-
-                    q8DataArray.setShortLe(q8ByteArrayWriteOffset, scaleF16Short)
-                    val qsDataWriteOffset = q8ByteArrayWriteOffset + SHORT_SIZE_BYTES
-
-                    for (k in 0 until QK8_0) {
-                        val fVal = f32BlockValues[k]
-                        val scaledVal = if (scaleF32 == 0.0f) 0.0f else fVal / scaleF32
-                        var iVal = round(scaledVal).toInt()
-                        iVal = iVal.coerceIn(-128, 127) // ggml q8 is typically -128 to 127
-                        q8DataArray[qsDataWriteOffset + k] = iVal.toByte()
-                    }
-                    q8ByteArrayWriteOffset += q8BlockByteSize
-                }
-                currentF32ElementIndex++
-            }
-            result.data = q8DataArray
-        }
-        GGMLType.Q8_1 -> { result.data = ByteArray(totalSize); println("Warning: Quantization F32 to ${targetType.name} not fully implemented.") }
         GGMLType.Q4_0, GGMLType.Q4_1 -> { result.data = ByteArray((totalSize + 1) / 2); println("Warning: Quantization F32 to ${targetType.name} not fully implemented.") }
         GGMLType.Q5_0, GGMLType.Q5_1 -> { result.data = ByteArray((totalSize * 5 + 7) / 8); println("Warning: Quantization F32 to ${targetType.name} not fully implemented.") }
-        // Add other Q types here if needed
+        GGMLType.Q8_0, GGMLType.Q8_1 -> { result.data = ByteArray(totalSize); println("Warning: Quantization F32 to ${targetType.name} not fully implemented.") }
         else -> {
             println("Error: Unsupported target quantization type $targetType in quantizeTensor")
             result.data = null


### PR DESCRIPTION
This pull request updates the Kotlin Native port of llama by removing the incomplete implementation of Q8_0 quantization and marking it as unimplemented. Additionally, it cleans up unused imports in `GGMLComputeOps.kt`. Below is a summary of the most important changes:

### Removal of Q8_0 quantization implementation:
* [`src/nativeMain/kotlin/ai/solace/llamakotlin/core/GGMLComputeOps.kt`](diffhunk://#diff-197a5838b77ac754c1bc06608db284bf5aae8e19675e7a9a1ae088e22fbbb76aL233-R232): Removed the incomplete implementation of Q8_0 quantization logic from the `quantizeTensor` function. This includes the block structure handling, scaling logic, and data array population. Q8_0 is now marked as unimplemented with a warning message.

### Documentation update:
* [`KOTLIN_PORT_CHECKLIST.md`](diffhunk://#diff-5afca192500b4f3e1ba89ab6d504a81cedf37e04654f5c4ccaad070cbc97958eL84-R84): Updated the checklist to reflect that Q8_0 quantization is not yet implemented, changing its status from completed (`[x]`) to pending (`[ ]`).

### Code cleanup:
* [`src/nativeMain/kotlin/ai/solace/llamakotlin/core/GGMLComputeOps.kt`](diffhunk://#diff-197a5838b77ac754c1bc06608db284bf5aae8e19675e7a9a1ae088e22fbbb76aL4-L6): Removed unused imports (`kotlin.math.abs`, `kotlin.math.round`, and `kotlin.Short.Companion.SIZE_BYTES`) to improve code readability and reduce clutter.