### PR TITLE
Add unit tests for activation and RMSNorm functions

### DIFF
--- a/CPP_CORE_ANALYSIS.md
+++ b/CPP_CORE_ANALYSIS.md
@@ -1,0 +1,215 @@
+# Llama.cpp C/C++ Core Components Analysis and Kotlin Port Mapping
+
+## 1. Introduction
+
+**Purpose:** To analyze key components of the `llama.cpp` `ggml` library (core, memory allocation, backend system, CPU/Metal specifics) and map them to the current structure of the Kotlin Native port. This analysis aims to ensure functional alignment, identify key differences in implementation and design, and guide future development of the Kotlin port, particularly towards robust memory management, backend integration, and efficient computation.
+
+This document also keeps in mind long-term architectural goals for the Kotlin port, such as leveraging Kotlin's strengths for parallelism and concurrency (e.g., coroutines, actors, channels) for non-blocking I/O and parallel graph execution, though the immediate focus is on understanding the C/C++ baseline.
+
+## 2. Analysis of `llama.cpp` `ggml` Library Components
+
+This section summarizes the findings from reviewing the C/C++ source code of `ggml`.
+
+**2.1. Core GGML (`ggml.h`, `ggml.c`)**
+
+*   **Key Data Structures:**
+    *   `struct ggml_object`: A fundamental structure for memory management within a `ggml_context`. It tracks the offset, size, and type (tensor, graph, work buffer) of allocated blocks.
+    *   `struct ggml_context`: Manages a large, contiguous memory pool. All tensors and objects are typically allocated from this pool. It supports scratch buffers for temporary data during computation.
+    *   `struct ggml_tensor`: The central N-dimensional array (tensor) representation. Contains:
+        *   `type`: An `enum ggml_type` indicating the data type (F32, F16, various Q_types, etc.).
+        *   `backend`: (Deprecated) Previously indicated storage location; now `buffer->buft` is used.
+        *   `buffer`: A pointer to `struct ggml_backend_buffer`, linking the tensor to a specific backend's memory.
+        *   `ne[GGML_MAX_DIMS]`: Dimensions (shape) of the tensor.
+        *   `nb[GGML_MAX_DIMS]`: Strides in bytes for each dimension, crucial for non-contiguous memory access.
+        *   `op`: An `enum ggml_op` specifying the operation that generated this tensor.
+        *   `op_params`: An array storing parameters specific to the `op` (e.g., epsilon for normalization, axes for permutation).
+        *   `grad`, `src[GGML_MAX_SRC]`: Pointers used to build the computation graph, linking to the gradient tensor and source (operand) tensors.
+        *   `view_src`, `view_offs`: For view tensors, `view_src` points to the tensor whose data is shared, and `view_offs` is the byte offset into `view_src->data`.
+        *   `data`: A `void*` pointer to the tensor's actual data, managed by a backend buffer.
+        *   `name`: An optional name for debugging.
+    *   `struct ggml_cgraph`: Represents the computation graph. It includes arrays of `ggml_tensor*` for nodes (in execution order), leaf nodes (inputs/parameters), and gradients (if applicable). A hash set (`visited_hash_set`) is used to efficiently track visited nodes during graph construction.
+    *   `struct ggml_cplan`: A compute plan for a graph, containing the required workspace buffer (`work_data`, `work_size`) and threading information (`n_threads`) for `ggml_graph_compute`.
+
+*   **Core Enums:**
+    *   `enum ggml_type`: Defines all supported data types, including floating-point (F32, F16, BF16), various integer types, and a wide array of quantized types (Q4_0, Q4_1, Q8_0, different K-quants, IQ types).
+    *   `enum ggml_op`: Lists all tensor operations (e.g., ADD, MUL, MUL_MAT, NORM, RMS_NORM, ROPE, SOFT_MAX, CONV_*, FLASH_ATTN_EXT).
+
+*   **Tensor & Graph Management:**
+    *   Tensors are created within a `ggml_context` using functions like `ggml_new_tensor()`, `ggml_new_tensor_1d()`, etc. These functions also calculate default strides.
+    *   View operations (e.g., `ggml_reshape`, `ggml_transpose`) create new `ggml_tensor` structs that share data with an existing tensor but have different metadata (shape, strides).
+    *   Graph building functions like `ggml_build_forward_expand()` and `ggml_build_backward_expand()` traverse tensor relationships (via `src` pointers) to create an ordered list of operations for execution.
+
+*   **CPU Computation:**
+    *   The actual computation logic for each op on the CPU is implemented in `ggml_compute_forward_OPNAME` functions within `ggml.c`.
+    *   These functions often contain SIMD-optimized code paths for architectures like NEON, AVX, AVX2, AVX512, using preprocessor macros to select the appropriate intrinsics.
+    *   Quantization and dequantization routines (defined in `ggml-quants.c/h` and accessed via `ggml_type_traits_t`) are heavily used for operations involving quantized types.
+    *   Multi-threading for graph computation on CPU is managed by `ggml_graph_compute()` which uses `ggml_graph_compute_thread()` and a `ggml_compute_params` struct to distribute work among threads. Synchronization is typically handled with a custom barrier.
+
+**2.2. Memory Allocation (`ggml-alloc.h`, `ggml-alloc.c`)**
+
+*   **`struct ggml_tallocr` (Tensor Allocator):**
+    *   A simple linear "bump" allocator that operates on a pre-defined `ggml_backend_buffer_t`. It advances an offset to allocate memory for individual tensors. Primarily used by utilities like `ggml_backend_alloc_ctx_tensors_from_buft`.
+
+*   **`ggml_gallocr_t` (Graph Allocator - `struct ggml_gallocr` in `.c`):**
+    *   Manages memory for an entire computation graph, potentially across multiple backend buffers.
+    *   **Internal `ggml_dyn_tallocr`:** Uses one or more instances of `ggml_dyn_tallocr` (dynamic tensor allocator) internally. `ggml_dyn_tallocr` manages `free_block`s within a buffer, supporting allocation and deallocation with merging of free blocks. This is the core of the planning phase.
+    *   **Usage Counting (`hash_node`):** Employs a hash table to store `struct hash_node` for each tensor. This node tracks the number of children (nodes that use this tensor as input) and views, which is critical for determining when a tensor's memory can be freed or reused.
+    *   **Two-Pass System:**
+        1.  **Reserve/Measure Pass (`ggml_gallocr_reserve_n`):**
+            *   Performs a "dry run" of the graph allocation using `ggml_dyn_tallocr` for each buffer.
+            *   Simulates allocations, inplace reuses, and deallocations to determine the peak memory requirement (`max_size`) for each buffer.
+            *   **Inplace Reuse:** For operations marked `ggml_op_can_inplace`, if a parent tensor is only used by the current node, has no other views, is not a graph output, and layouts match, its memory region is reused by the current node. The parent is then marked as "not allocated by graph allocator" to prevent its memory from being freed by `ggml_dyn_tallocr_free_tensor`.
+            *   **Deallocation:** When a tensor's children and view counts drop to zero (and it's not an output), its memory region is marked as free in the `ggml_dyn_tallocr`.
+            *   After the dry run, actual `ggml_backend_buffer_t` instances are allocated (or reallocated if already existing) to the determined `max_size`.
+            *   The planned offsets and buffer assignments are stored.
+        2.  **Allocation Pass (`ggml_gallocr_alloc_graph`):**
+            *   Uses the plan from the reserve pass.
+            *   Sets the `data` pointer and `buffer` field of each tensor in the user's graph by calling `ggml_backend_tensor_alloc()` (for new allocations) or `ggml_backend_view_init()` (for views) using the stored offsets and buffer instances.
+
+**2.3. Backend System (`ggml-backend.h`, `ggml-backend.c`)**
+
+*   **Abstractions:**
+    *   `ggml_backend_t`: An opaque handle to a backend (e.g., CPU, specific GPU). Contains an interface (`ggml_backend_i`) of function pointers for backend-specific operations and a backend-specific context.
+    *   `ggml_backend_buffer_type_t`: Describes a *type* of memory a backend can use (e.g., CPU RAM, GPU VRAM). It also has an interface for operations like allocating a buffer of its type.
+    *   `ggml_backend_buffer_t`: An instance of a memory buffer on a particular backend, associated with a `ggml_backend_buffer_type_t`.
+*   **CPU Backend:**
+    *   The default backend, implemented in `ggml-backend.c`.
+    *   Its buffer type (`ggml_backend_cpu_buffer_type()`) manages host RAM.
+    *   `ggml_backend_cpu_graph_compute()` uses `ggml_graph_compute()` (from `ggml.c`) for execution, respecting threading settings in its context.
+*   **Backend Registry (`ggml_backend_reg_...`):**
+    *   Allows discovery and initialization of available backends (CPU, CUDA, Metal, etc., if compiled in).
+*   **Scheduler (`ggml_backend_sched_t`):**
+    *   Orchestrates graph execution across multiple, potentially heterogeneous, backends.
+    *   **Graph Splitting:** `ggml_backend_sched_split_graph()` analyzes the graph and backend capabilities/assignments to divide the graph into "splits," where each split runs on a single backend. It inserts tensor copy operations where data needs to move between backends.
+    *   **Memory Management:** Uses `ggml_gallocr_t` to manage memory allocation across all configured backends for the scheduler.
+    *   **Execution:** `ggml_backend_sched_graph_compute_async()` executes the splits, managing data copies and dispatching compute tasks to the respective backends.
+
+**2.4. Metal Backend (`ggml-metal.m`)**
+
+*   **Context (`struct ggml_backend_metal_context`):** Holds `id<MTLDevice>`, `id<MTLCommandQueue>`, and an array of compiled Metal compute shaders (`id<MTLComputePipelineState>`) indexed by `enum ggml_metal_kernel_type`.
+*   **Kernel Management:**
+    *   Metal Shading Language (MSL) code is in `ggml-metal.metal`.
+    *   Kernels are compiled at initialization (`ggml_metal_init`) either from embedded source or an external `.metallib` file.
+*   **Buffer Management:**
+    *   Leverages Apple's Unified Memory model (`MTLResourceStorageModeShared`). Buffers (`id<MTLBuffer>`) are created from host-allocated page-aligned memory, accessible by both CPU and GPU.
+    *   `ggml_metal_get_buffer()` is an internal helper to map a `ggml_tensor` (via its `data` pointer which points into a host-allocated region) to the corresponding `id<MTLBuffer>` and offset within it.
+*   **Graph Computation (`ggml_metal_graph_compute`):**
+    *   Uses Grand Central Dispatch (`dispatch_apply`) to encode commands into multiple `MTLCommandBuffer`s in parallel.
+    *   For each Metal-compatible op:
+        *   Retrieves the pre-compiled kernel.
+        *   Sets the kernel on a `MTLComputeCommandEncoder`.
+        *   Binds `MTLBuffer`s (for src/dst tensors) and scalar parameters to the encoder.
+        *   Dispatches the kernel using `dispatchThreadgroups`.
+    *   Command buffers are committed and synchronized.
+*   **Supported Ops:** A wide range of ops have Metal kernels, including element-wise, matrix multiplications (various Q-types vs F32), RoPE, normalization, etc. Support may depend on GPU family features.
+
+## 3. Mapping of Kotlin Port to `llama.cpp` Components
+
+This section details how the existing Kotlin port files align with the C/C++ components.
+
+**3.1. `GGMLTypes.kt` (and `NumericConversions.kt`)**
+
+*   **C/C++ Counterparts:** `ggml.h` (for `enum ggml_type`, `enum ggml_op`, `struct ggml_tensor`'s field definitions, quantization constants like `QK_K`), `ggml-quants.h` (for definitions of block structures like `block_q8_0`, `block_q4_0`, `block_q4_1`). `NumericConversions.kt` relates to `ggml_fp16_to_fp32`/`ggml_fp32_to_fp16` in `ggml.c`.
+*   **Responsibilities & Alignment (Kotlin):**
+    *   Defines core data structures: `GGMLTensor` class, `GGMLType` enum, `GGMLOp` enum. Also includes constants like `QK8_0`, `QK4_0`, `QK4_1`, `GGML_MAX_DIMS`, `GGML_TENSOR_FLAG_OUTPUT`. `NumericConversions.kt` provides `halfToFloat`, `floatToHalf`, and `ByteArray` LE accessors.
+    *   `GGMLType`: Maps to `enum ggml_type`. Includes `byteSize` (per-block for Q-types like Q4_0, Q8_0, Q4_1; per-element otherwise) and a `description`.
+    *   `GGMLOp`: Maps to `enum ggml_op`. Includes a `canBeInplace: Boolean` property, reflecting characteristics derived from `ggml.c`.
+    *   `GGMLTensor`: Represents `struct ggml_tensor`. Holds `type`, `op`, `flags`, `ne` (dimensions), `nb` (strides as `ULongArray`), `viewOffs`, `src` array. Data access is abstracted via `bufferId: Int` and `dataOffset: ULong` which point to memory managed by `GGMLGraphAllocator`. Accessor methods (`getFloat`, `setFloat`, `getQ8_0BlockScale`, etc.) require a `GGMLGraphAllocator` instance. Helper methods: `numElements()`, `rank()`, `isValidZeroSizedTensor()`, `getNumBlocks()`.
+*   **Differences:**
+    *   Kotlin is object-oriented.
+    *   **Data Abstraction:** `GGMLTensor` does not hold a direct data pointer; access is mediated by `GGMLGraphAllocator` via `bufferId`/`dataOffset`. This is a major difference from C's `void* data`.
+    *   Some C `ggml_tensor` fields like `grad`, `backend`, `op_params` (partially added later), and performance counters are not fully present or handled differently.
+    *   `nb` strides are `ULongArray`.
+*   **Kotlin Dependencies:** `NumericConversions.kt` (for type conversions, byte array access). `GGMLAlloc.kt` (for `GGMLGraphAllocator` needed by tensor data accessors).
+*   **Anticipated Backend Interactions:**
+    *   `GGMLTensor` instances (with `type`, `ne`, `nb`, `bufferId`, `dataOffset`) will be fundamental for Kotlin backends to interpret data layout within backend-managed buffers.
+    *   `GGMLType` and `GGMLOp` will guide kernel selection and dispatch on backends.
+
+**3.2. `GGMLOps.kt`**
+
+*   **C/C++ Counterparts:** `ggml.h` (for declarations of op functions like `ggml_add`, `ggml_mul_mat`), `ggml.c` (for implementations that build graph nodes by setting `tensor->op` and `tensor->src[]`).
+*   **Responsibilities & Alignment (Kotlin):**
+    *   Provides tensor factory functions (`createTensor`, `createTensor1D`, `createTensor2D`) which initialize `GGMLTensor` instances, including their `ne` and `nb` (using `calculateContiguousStrides`).
+    *   Defines symbolic operation functions (e.g., `add(a,b)`, `relu(a)`) that create a result `GGMLTensor`, set its `op` and `src` fields to define the graph node.
+    *   The `calculateContiguousStrides` helper function was recently added here.
+*   **Differences:**
+    *   **Immediate Computation:** Kotlin op functions in `GGMLOps.kt` have a `context.computeImmediately` path that directly calls computation functions from `GGMLComputeOps.kt`. In C, these functions strictly define graph structure; computation is separate.
+    *   **Result Tensor Memory:** These Kotlin functions create `GGMLTensor` objects for results. Unlike C where `tensor->data` would point to memory within the `ggml_context` (often allocated later by a graph allocator), these result tensors in Kotlin don't have their `bufferId`/`dataOffset` set by `GGMLOps.kt`. If `computeImmediately` is true, the compute function in `GGMLComputeOps.kt` typically allocates its own data array for the result.
+*   **Kotlin Dependencies:** `GGMLTypes.kt` (for `GGMLTensor`, `GGMLType`, `GGMLOp`, `GGMLContext`), `GGMLComputeOps.kt` (if `computeImmediately` is true).
+*   **Anticipated Backend Interactions:**
+    *   The primary role is to build the `GGMLCGraph` structure (composed of `GGMLTensor` nodes from `GGMLTypes.kt`) which is then passed to backends or a scheduler.
+    *   The `computeImmediately` path would need to be adapted for backends, potentially by dispatching to a backend's immediate execution function.
+
+**3.3. `GGMLAlloc.kt`**
+
+*   **C/C++ Counterparts:** `ggml-alloc.h/c` (defines `ggml_gallocr_t` and its logic, including the internal `ggml_dyn_tallocr`).
+*   **Responsibilities & Alignment (Kotlin):**
+    *   `GGMLGraphAllocator`: Analogous to `ggml_gallocr_t`. Manages memory for graphs.
+        *   It uses `MutableList<ByteArray?>` for buffers (currently one main buffer).
+        *   It employs `GGMLDynTensorAllocator` instances (one per `ByteArray`) for sub-allocation within these buffers.
+        *   `analyzeTensorUsage()`: Counts children/views, similar to C.
+        *   `allocateTensor()`: Assigns `bufferId` and `dataOffset`. Implements inplace reuse and frees unneeded tensor regions by interacting with `GGMLDynTensorAllocator`. Handles valid zero-sized tensors.
+        *   `allocateGraph()`: Orchestrates allocation by iterating nodes and calling `allocateTensor`.
+        *   `ensureBufferCapacity()`: Resizes `ByteArray`s if `GGMLDynTensorAllocator`'s `maxSize` indicates more space was needed than available. Throws an error for invalid requested sizes.
+    *   `GGMLDynTensorAllocator`: Manages `FreeBlock`s within a `ByteArray`, similar to C's internal `ggml_dyn_tallocr`.
+*   **Differences:**
+    *   **Buffer Type:** Manages concrete `ByteArray`s (CPU memory) instead of abstract `ggml_backend_buffer_t` which could be on any device.
+    *   **Allocation Pass:** Kotlin's `allocateGraph` combines the measurement/planning and "actual" assignment of offsets within its `ByteArray`s into a single pass. C's `ggml_gallocr_t` has a more distinct two-pass system (`reserve` then `alloc_graph`).
+    *   The C graph allocator uses `ggml_backend_tensor_alloc` to bind tensor to buffer memory, while Kotlin's `allocateTensor` directly sets `bufferId`/`dataOffset` which are then used by `GGMLTensor` accessors.
+*   **Kotlin Dependencies:** `GGMLTypes.kt` (for `GGMLTensor`, `GGMLType`, `TensorUsageInfo`).
+*   **Anticipated Backend Interactions:**
+    *   This component is currently a CPU-specific memory manager.
+    *   For other backends (e.g., Metal), `GGMLGraphAllocator` would need to be heavily adapted to manage backend-specific buffer objects (e.g., `id<MTLBuffer>`) instead of `ByteArray`s. The `GGMLDynTensorAllocator`'s logic for managing regions within a larger buffer could still be relevant if a backend uses large pre-allocated buffers.
+    *   The core logic for usage tracking and inplace decisions would be similar but would operate on backend-specific memory objects.
+
+**3.4. `GGMLComputeOps.kt`**
+
+*   **C/C++ Counterparts:** `ggml.c` (for `ggml_compute_forward_OPNAME` CPU routines), `ggml-quants.c/h` (for (de)quantization logic).
+*   **Responsibilities & Alignment (Kotlin):**
+    *   Provides Kotlin implementations for actual tensor computations (e.g., `computeAdd`, `computeMatMul`, `computeRelu`).
+    *   `quantizeTensor` and `dequantizeTensor` for F32 <-> Q8_0, Q4_0, Q4_1, F16.
+    *   Includes specialized dot product functions for mixed-precision MatMul (e.g., `computeDotProductQ41F32`).
+*   **Differences:**
+    *   **Result Handling:** Many Kotlin compute ops return *new* `GGMLTensor` instances with their own self-contained `.data` (`FloatArray`, `ByteArray`). This differs from `ggml.c` where computations usually write into a pre-allocated `dst->data` pointer managed by the graph allocator.
+    *   **No SIMD:** Implementations are standard Kotlin, lacking the explicit SIMD optimizations found in `ggml.c`.
+    *   **CPU Only:** All logic is for CPU execution. No backend dispatch mechanism.
+*   **Kotlin Dependencies:** `GGMLTypes.kt` (for `GGMLTensor`, `GGMLType`, accessors), `GGMLAlloc.kt` (for `GGMLGraphAllocator` needed by accessors), `NumericConversions.kt`.
+*   **Anticipated Backend Interactions:**
+    *   This file currently *is* the CPU compute engine. A formal CPU backend would likely use or encapsulate this logic.
+    *   For a Metal backend, compute functions here would be replaced by calls that dispatch Metal kernels. The Kotlin `GGMLTensor` metadata would be passed to the Metal backend to identify data in `MTLBuffer`s. Data preparation (quantization/dequantization) might occur on CPU via these functions before transfer to GPU, or the Metal backend might have its own kernels for these.
+
+## 4. Key Architectural Observations & Considerations for Kotlin Port
+
+*   **Memory Management:**
+    *   The Kotlin port uses `GGMLGraphAllocator` to manage `ByteArray`s, with `GGMLTensor` instances referring to data via `bufferId` and `dataOffset`. Tensor data access is mediated by accessor methods on `GGMLTensor` that require a `GGMLGraphAllocator`.
+    *   This is a workable CPU-based memory model but differs from `ggml.c`'s more abstract `ggml_backend_buffer_t` system which allows different memory types (CPU, GPU).
+    *   To support backends like Metal, `GGMLGraphAllocator` will need to be adapted to manage backend-specific buffer objects instead of `ByteArray`s, and `GGMLTensor`'s `bufferId` would refer to these.
+
+*   **Compute Operation Results:**
+    *   A significant current difference is that many functions in `GGMLComputeOps.kt` (including `quantizeTensor`, `dequantizeTensor`, and various ops like `computeAdd`, `computeMatMul`) return new `GGMLTensor` instances containing their own freshly allocated data arrays (e.g., `FloatArray` in `tensor.data`).
+    *   In `ggml.c`, computation graph operations (like `ggml_add`) only define the graph structure. The `dst` tensor's data pointer is typically set by the graph allocator (`ggml_gallocr_alloc_graph`) to point to a region within a managed buffer, and the compute functions (`ggml_compute_forward_...`) write into this pre-allocated region.
+    *   This difference in the Kotlin port will need to be addressed for efficient graph execution and memory management, especially with backends. Results should ideally be written into buffers managed by the graph allocator as per the graph's plan.
+
+*   **Parallelism & Concurrency (User Goals):**
+    *   The user has expressed interest in leveraging Kotlin's concurrency features (coroutines, actors, channels) for non-blocking I/O and parallelism.
+    *   `llama.cpp`'s `ggml` uses a threading model for CPU graph computation (`ggml_graph_compute_thread`) and backends like Metal operate asynchronously.
+    *   The Kotlin port should aim to incorporate a robust concurrency model. This could involve:
+        *   Parallelizing graph computation across available cores (similar to `ggml.c`).
+        *   Asynchronous operations for backend execution (Metal already works this way).
+        *   Using coroutines for managing I/O (e.g., model loading) and potentially for coordinating graph execution stages if a more complex scheduler (like `ggml_backend_sched_t`) is implemented.
+
+*   **Modularity:**
+    *   The current separation into `GGMLTypes.kt` (data structures), `GGMLOps.kt` (graph node creation), `GGMLAlloc.kt` (memory allocation logic), and `GGMLComputeOps.kt` (CPU computation logic) provides a reasonable modular base.
+    *   Future backend implementations (e.g., `GGMLMetalBackend.kt`) would fit into this by providing their own computation logic and buffer management, interacting with `GGMLTensor` metadata and the graph structure. A backend scheduler similar to `ggml_backend_sched_t` would be needed for multi-backend support.
+
+## 5. Conclusion
+
+The Kotlin port has successfully established core data structures (`GGMLTensor`, `GGMLType`, `GGMLOp`) and a graph-based memory allocator (`GGMLGraphAllocator`) that mirrors several key concepts from `ggml.c` and `ggml-alloc.c`, including inplace tensor reuse and basic dynamic allocation within buffers (currently `ByteArray`s). CPU computation logic for several operations, including quantization and dequantization for Q4_0, Q4_1, and Q8_0, is present in `GGMLComputeOps.kt`.
+
+Key differences and areas for future focus include:
+*   **Backend Abstraction:** The current memory and computation are CPU-centric. A proper backend abstraction layer (similar to `ggml_backend_t` and `ggml_backend_buffer_type_t`) needs to be developed to support GPU backends like Metal. This will involve `GGMLGraphAllocator` managing generic backend buffers instead of `ByteArray`s.
+*   **Compute Result Handling:** Compute operations should ideally write results into memory managed by the graph allocator for `dst` tensors, rather than returning new tensors with self-contained data arrays, to align with `ggml`'s memory model for graph execution.
+*   **Advanced Graph Features:** Full graph planning (`ggml_graph_plan`), sophisticated scheduling (`ggml_backend_sched_t`), and automatic differentiation are extensive features in C `ggml` not yet fully ported.
+*   **SIMD/Performance:** Kotlin CPU compute operations currently lack explicit SIMD optimizations present in `ggml.c`. Performance optimization will be critical.
+
+The current analysis provides a solid foundation for understanding how the Kotlin port maps to `llama.cpp` and for planning the implementation of further features, particularly backend support and advanced memory/graph management.

--- a/KOTLIN_PORT_CHECKLIST.md
+++ b/KOTLIN_PORT_CHECKLIST.md
@@ -9,10 +9,10 @@ This checklist is based on the current state of the Kotlin Native port of llama.
   - [x] Configure build system (Gradle with Kotlin DSL)
   - [x] Setup project structure following Kotlin conventions
 
-- [ ] Analyze C/C++ Codebase
-  - [ ] Create a detailed map of all C/C++ files and their dependencies
-  - [ ] Identify platform-specific code (Metal, AVX, etc.)
-  - [ ] Document all external dependencies
+- [~] Analyze C/C++ Codebase
+  - [~] Create a detailed map of all C/C++ files and their dependencies (key core, CPU, Metal components and their roles mapped in CPP_CORE_ANALYSIS.md)
+  - [~] Identify platform-specific code (Metal, AVX, etc.) (Metal backend structure analyzed; CPU SIMD usage in ggml.c noted in CPP_CORE_ANALYSIS.md)
+  - [x] Document all external dependencies (core ggml, CPU, and Metal paths found to be largely self-contained, as noted in CPP_CORE_ANALYSIS.md)
   - [x] Separate code related to supported backends (CPU, Metal) from unsupported backends (GPU backends moved to archive)
 
 - [x] Design Kotlin Native Architecture
@@ -23,25 +23,39 @@ This checklist is based on the current state of the Kotlin Native port of llama.
 
 ## Phase 2: Core Library Translation (ggml) (In Progress)
 
-- [ ] Translate ggml Core Data Structures
+- [~] Translate ggml Core Data Structures
   - [x] Define tensor data types (GGMLType enum)
   - [x] Define tensor operations (GGMLOp enum)
   - [x] Implement tensor structure (GGMLTensor class)
   - [x] Implement context structure (GGMLContext class)
   - [x] Implement computation graph structure (GGMLCGraph class)
   - [x] Implement basic memory allocation structures (GGMLTensorAllocator, GGMLGraphAllocator)
-  - [x] Complete memory allocation implementation with actual functionality
+  - [~] Complete memory allocation implementation with actual functionality
+    - [x] Refactored GGMLGraphAllocator to use a primary ByteArray buffer.
+    - [x] GGMLTensor now stores bufferId and dataOffset, with GGMLGraphAllocator setting these.
+    - [x] reserveGraph now sizes the primary ByteArray appropriately and informs the dynamic allocator.
+    - [x] Implement efficient tensor data access methods/views into the backing ByteArray(s).
+      - [x] Added `nb` (strides) to `GGMLTensor` and populated it in new tensor creation functions.
+      - [x] Implemented `get/set` accessors on `GGMLTensor` for F32, I32, I16 using `ByteArray` helpers and stride information.
+      - [x] Refactored F32 compute operations in `GGMLComputeOps.kt` to use the new data accessors.
+      - [x] Implement F16 typed accessors and update relevant compute operations.
+      - [ ] Further optimize data access if performance bottlenecks are identified (e.g., exploring direct memory access if feasible).
+    - [x] Implement inplace tensor allocation and memory reuse logic in GGMLGraphAllocator.
+      - [x] Implemented tensor usage tracking (children, views, output status, memory ownership) via `TensorUsageInfo` and `tensorUsageMap`.
+      - [x] Added `canBeInplace` property to `GGMLOp` to identify suitable operations.
+      - [x] `GGMLGraphAllocator.allocateTensor` now attempts inplace allocation by reusing eligible parent tensor memory.
+      - [x] Implemented memory freeing logic within `GGMLGraphAllocator.allocateGraph` to deallocate memory of tensors (and view sources) once they are no longer referenced.
 
-- [x] Implement Basic Tensor Operations
+- [~] Implement Basic Tensor Operations
   - [x] Implement tensor creation functions (createTensor, createTensor1D, createTensor2D)
   - [x] Define element-wise operations interfaces (add, mul)
   - [x] Define matrix multiplication interface (matMul)
-  - [x] Implement actual computation for tensor operations (computeAdd, computeMul, computeMatMul) and integrate with high-level ops
-  - [x] Implement activation functions (computeRelu, computeGelu)
-  - [x] Implement support for all tensor data types (F32, F16, I8, I16, I32, I64)
-  - [x] Implement optimized versions of tensor operations
+  - [~] Implement actual computation for tensor operations (computeAdd, computeMul, computeMatMul) and integrate with high-level ops (F32/F16/some Q_x_F32 MatMul done; other types/ops pending full coverage)
+  - [~] Implement activation functions (computeRelu, computeGelu) (Initial F32/F16 ops exist, testing pending)
+  - [~] Implement support for all tensor data types (F32, F16, I8, I16, I32, I64) in compute ops (F32/F16 good, I-types often via array access)
+  - [~] Implement optimized versions of tensor operations (specific dot products for Q_types done; general optimization pending)
 
-- [ ] Implement Computation Graph
+- [~] Implement Computation Graph
   - [x] Implement forward pass computation
   - [x] Implement automatic differentiation (partial implementation)
     - [x] Implement backward pass for ADD, SUB, MUL, NEG operations
@@ -54,14 +68,39 @@ This checklist is based on the current state of the Kotlin Native port of llama.
     - [ ] Implement backward pass for remaining operations
   - [ ] Implement graph optimization
 
-- [ ] Implement Quantization Support
+- [~] Implement Quantization Support
   - [ ] Implement 1.5-bit integer quantization
   - [ ] Implement 2-bit integer quantization
   - [ ] Implement 3-bit integer quantization
-  - [ ] Implement 4-bit integer quantization
+  - [~] Implement 4-bit integer quantization (Q4_0 focused)
+    - [x] Defined Q4_0 block structure (F16 scale + 32x4-bit packed weights, type.byteSize = 18).
+    - [x] Implemented data accessors for Q4_0 blocks (`getQ4_0BlockScale`, `getQ4_0NibbleWeight`).
+    - [x] Implemented Q4_0 to F32 dequantization in `dequantizeTensor`.
+    - [x] Implement Q4_0 quantization (F32 to Q4_0) in `quantizeTensor`.
+    - [~] Implement optimized Q4_0 dot product routines (e.g., for MatMul with F32).
+      - [x] Implemented `computeDotProductQ40F32` for efficient Q4_0 x F32 operations.
+      - [x] Refactored `computeMatMul` to use the optimized dot product for (Q4_0 x F32 -> F32) cases.
+      - [ ] Consider optimized dot product for the symmetric F32 x Q4_0 case (currently uses dequantization).
+  - [~] Implement 4-bit integer quantization (Q4_1 focused)
+    - [x] Defined Q4_1 block structure (2x F16 scale/min + 32x4-bit packed weights, type.byteSize = 20).
+    - [x] Implemented data accessors for Q4_1 blocks (`getQ4_1BlockScale`, `getQ4_1BlockMin`, `getQ4_1NibbleWeight`).
+    - [x] Implemented Q4_1 to F32 dequantization in `dequantizeTensor`.
+    - [x] Implemented F32 to Q4_1 quantization in `quantizeTensor`.
+    - [~] Implement optimized Q4_1 dot product routines (e.g., for MatMul with F32).
+      - [x] Implemented `computeDotProductQ41F32` for efficient Q4_1 x F32 operations.
+      - [x] Refactored `computeMatMul` to use the optimized dot product for (Q4_1 x F32 -> F32) cases.
+      - [ ] Consider optimized dot product for the symmetric F32 x Q4_1 case (currently uses dequantization).
   - [ ] Implement 5-bit integer quantization
   - [ ] Implement 6-bit integer quantization
-  - [ ] Implement 8-bit integer quantization
+  - [~] Implement 8-bit integer quantization (Q8_0 focused)
+    - [x] Defined Q8_0 block structure (F16 scale + 32xI8 weights, type.byteSize = 34).
+    - [x] Implemented data accessors for Q8_0 blocks (`getQ8_0BlockScale`, `getQ8_0Weight`).
+    - [x] Implemented Q8_0 to F32 dequantization in `dequantizeTensor`.
+    - [x] Implement Q8_0 quantization (F32 to Q8_0) in `quantizeTensor`.
+    - [~] Implement optimized Q8_0 dot product routines (e.g., for MatMul with F32).
+      - [x] Implemented `computeDotProductQ80F32` for efficient Q8_0 x F32 operations.
+      - [x] Refactored `computeMatMul` to use the optimized dot product for (Q8_0 x F32 -> F32) cases.
+      - [ ] Consider optimized dot product for the symmetric F32 x Q8_0 case (currently uses dequantization).
   - [ ] Implement quantized operations
 
 ## Phase 3: CPU Backend Implementation
@@ -141,10 +180,26 @@ This checklist is based on the current state of the Kotlin Native port of llama.
 
 ## Phase 8: Testing and Validation
 
-- [ ] Implement Unit Tests
-  - [ ] Test core tensor operations
+- [~] Implement Unit Tests
+  - [~] Test core tensor operations (computation logic in GGMLComputeOps) # Marked as in-progress
+    - [x] Test element-wise ADD for F32 (1D, 2D) and F16 (1D).
+    - [x] Test element-wise MUL for F32 (1D) and F16 (1D).
+    - [x] Test `computeMatMul` for F32 x F32 operations.
+    - [x] Test `computeMatMul` for Q8_0 x F32 operations (optimized path, comparing against F32 reference).
+    - [x] Test activation functions (RELU, GELU, SILU) for F32 and F16 types.
+    - [x] Test RMSNorm function for F32 and F16 types.
+    - [ ] Test operations with other data type combinations as they become supported (e.g., I32, other quantized types).
+    - [ ] Test other specific core operations not yet covered.
   - [ ] Test model inference
-  - [ ] Test quantization accuracy
+  - [~] Test quantization accuracy
+    - [x] Implemented Q8_0 quantize-dequantize accuracy test (verifying with MSE and MAD).
+    - [x] Implemented Q4_0 quantize-dequantize accuracy test (verifying with MSE and MAD).
+    - [x] Implemented Q4_1 quantize-dequantize accuracy test (verifying with MSE and MAD).
+    - [ ] Test accuracy for other future quantization types as they are implemented (e.g., Q2_K, Q3_K, Q5_K, Q6_K).
+    - [ ] Define and use standardized test datasets and error metric thresholds for comprehensive validation of all supported types.
+  - [x] Test `GGMLDynTensorAllocator` (dynamic memory allocation within a buffer).
+  - [x] Test `GGMLGraphAllocator` (graph-level memory planning: reserve, inplace allocation, freeing).
+  - [x] Test `GGMLTensor` data accessors (low-level read/write for F32, I32, I16, F16).
 
 - [ ] Implement Integration Tests
   - [ ] Test end-to-end model loading and inference
@@ -158,7 +213,7 @@ This checklist is based on the current state of the Kotlin Native port of llama.
 
 ## Phase 9: Documentation and Distribution
 
-- [ ] Create Documentation
+- [~] Create Documentation
   - [x] Create design documents for tensor operations (TENSOR_OPERATIONS_DESIGN.md)
   - [x] Create design documents for compute operations (GGML_COMPUTE_OPS_DESIGN.md)
   - [x] Document current status (KOTLIN_PORT_STATUS.md)
@@ -195,27 +250,28 @@ This checklist is based on the current state of the Kotlin Native port of llama.
 
 ## Next Steps
 
-Based on the current state of the project, the immediate next steps should be:
+With foundational memory management, data access, and initial quantization types (Q8_0, Q4_0, Q4_1) in place, the immediate priorities are:
 
-1. Complete the implementation of tensor operations
-   - Implement support for all tensor data types
-   - Optimize tensor operations for performance
-   - Implement the computation graph execution
+1.  **Advance Quantization Support:**
+    *   Implement a K-Quant type (e.g., Q4_K or Q2_K), including its structure, accessors, quant/dequant routines.
+    *   Implement optimized dot product routines for symmetric cases (e.g., F32 x Q_type for Q8_0, Q4_0, Q4_1) and for new K-Quant types.
+    *   Test quantization accuracy for all newly supported types (e.g., Q4_1 accuracy test is pending).
 
-2. Implement the CPU backend
-   - Implement basic CPU tensor operations
-   - Optimize for different CPU architectures
-   - Implement multi-threading support
+2.  **Strengthen Core Operations and Testing:**
+    *   Implement and write unit tests for remaining core tensor operations in `GGMLComputeOps.kt` (e.g., common activation functions like SILU; normalization layers like RMSNorm) for F32/F16 types. (Note: GELU/RELU tests were planned next).
+    *   Ensure all basic compute operations have proper handling or clear strategies for all fundamental (non-quantized) data types (I8, I32, I64).
+    *   Begin work on "Implement graph optimization" from Phase 2.
 
-3. Set up unit tests for the implemented components
-   - Create unit tests for tensor operations
-   - Create unit tests for memory allocation
-   - Create integration tests for the computation graph
+3.  **Initiate CPU Backend Development (Phase 3):**
+    *   Formalize the CPU backend structure.
+    *   Start integrating current `GGMLComputeOps.kt` logic into this backend.
+    *   Investigate and implement initial multi-threading for graph computation on CPU.
 
-4. Begin implementing the Metal backend for Apple Silicon
-   - Implement Metal shader code
-   - Implement Metal backend for tensor operations
-   - Optimize for Apple Silicon
+4.  **Begin Foundational GGUF Support (Phase 6):**
+    *   Start implementing GGUF file parsing (reading headers, tensor info, quantization types). This is crucial for loading models.
+
+5.  **(Stretch Goal / Parallel) Initial Metal Backend Exploration (Phase 4):**
+    *   Begin basic Metal context setup and experiment with compiling/running a simple Metal compute shader for a single ggml operation.
 
 ## Build Environment
 

--- a/src/nativeMain/kotlin/ai/solace/llamakotlin/core/GGMLComputeOps.kt
+++ b/src/nativeMain/kotlin/ai/solace/llamakotlin/core/GGMLComputeOps.kt
@@ -1,5 +1,10 @@
 package ai.solace.llamakotlin.core
 
+import ai.solace.llamakotlin.core.GGMLGraphAllocator // Required for new function signatures
+import kotlin.math.abs
+import kotlin.math.round
+import kotlin.Short.Companion.SIZE_BYTES as SHORT_SIZE_BYTES
+
 /**
  * Kotlin Native port of GGML tensor computation operations.
  * This file contains the implementation of actual computation functionality for tensor operations.
@@ -21,16 +26,13 @@ fun calculateTotalSize(ne: LongArray): Int {
 
 /**
  * Allocates memory for a tensor based on its type and size.
- *
- * @param type The tensor data type
- * @param size The number of elements to allocate
- * @return The allocated memory as an appropriate array type
+ * (Note: This function is less relevant now that compute ops use graphAllocator for results)
  */
 @Suppress("unused")
 fun allocateMemory(type: GGMLType, size: Int): Any {
     return when (type) {
         GGMLType.F32 -> FloatArray(size) { 0.0f }
-        GGMLType.F16 -> ShortArray(size) { 0 }
+        GGMLType.F16 -> ShortArray(size) { 0 } // Still used by quantizeTensor for F16 intermediate
         GGMLType.I8 -> ByteArray(size) { 0 }
         GGMLType.I16 -> ShortArray(size) { 0 }
         GGMLType.I32 -> IntArray(size) { 0 }
@@ -40,1473 +42,787 @@ fun allocateMemory(type: GGMLType, size: Int): Any {
 }
 
 /**
+ * Computes the dot product of a row from a Q8_0 tensor and a column from an F32 tensor.
+ * Used as a core part of Q8_0 x F32 matrix multiplication.
+ * Assumes tensorQ80 (src0) is M x K (ne = [K, M])
+ * Assumes tensorF32 (src1) is K x N (ne = [N, K])
+ */
+internal fun computeDotProductQ80F32(
+    graphAllocator: GGMLGraphAllocator,
+    tensorQ80: GGMLTensor,    // M x K (ne[0]=K items per row, ne[1]=M rows)
+    tensorF32: GGMLTensor,    // K x N (ne[0]=N items per row, ne[1]=K rows)
+    rowIndexInQ80: Int,     // Row index 'i' for tensorQ80 (0 to M-1)
+    colIndexInF32: Int,     // Column index 'j' for tensorF32 (0 to N-1)
+    commonDimK: Int         // The shared dimension K (should be tensorQ80.ne[0] and tensorF32.ne[1])
+): Float {
+    require(tensorQ80.type == GGMLType.Q8_0) { "tensorQ80 must be Q8_0. Got ${tensorQ80.type}" }
+    require(tensorF32.type == GGMLType.F32) { "tensorF32 must be F32. Got ${tensorF32.type}" }
+    require(tensorQ80.ne[0].toInt() == commonDimK) { "tensorQ80 K dim (${tensorQ80.ne[0]}) must match commonDimK ($commonDimK)"}
+    require(tensorF32.ne[1].toInt() == commonDimK) { "tensorF32 K dim (${tensorF32.ne[1]}) must match commonDimK ($commonDimK)"}
+
+    var sumF32 = 0.0f
+    for (k in 0 until commonDimK) {
+        val flatIndexInQ80 = rowIndexInQ80 * commonDimK + k
+        val blockIndexQ80 = flatIndexInQ80 / QK8_0
+        val itemInBlockQ80 = flatIndexInQ80 % QK8_0
+        val scale = tensorQ80.getQ8_0BlockScale(graphAllocator, blockIndexQ80)
+        val qWeight = tensorQ80.getQ8_0Weight(graphAllocator, blockIndexQ80, itemInBlockQ80)
+        val dequantizedQ80Value = scale * qWeight.toFloat()
+        val f32Value = tensorF32.getFloat(graphAllocator, colIndexInF32, k)
+        sumF32 += dequantizedQ80Value * f32Value
+    }
+    return sumF32
+}
+
+internal fun computeDotProductQ41F32(
+    graphAllocator: GGMLGraphAllocator,
+    tensorQ41: GGMLTensor,    // Assumed layout M x K (ne[1] = M rows, ne[0] = K elements per row for access)
+    tensorF32: GGMLTensor,    // Assumed layout K x N (ne[1] = K rows, ne[0] = N columns for access)
+    rowIndexInQ41: Int,     // Row index 'i' for tensorQ41 (0 to M-1)
+    colIndexInF32: Int,     // Column index 'j' for tensorF32 (0 to N-1)
+    commonDimK: Int         // The shared dimension K, should match tensorQ41.ne[0] and tensorF32.ne[1]
+): Float {
+    require(tensorQ41.type == GGMLType.Q4_1) { "computeDotProductQ41F32: tensorQ41 must be Q4_1. Got ${tensorQ41.type}" }
+    require(tensorF32.type == GGMLType.F32) { "computeDotProductQ41F32: tensorF32 must be F32. Got ${tensorF32.type}" }
+
+    // Validate dimensions for clarity and robustness
+    val M_q41 = tensorQ41.ne[1].toInt()
+    val K_q41 = tensorQ41.ne[0].toInt()
+    val K_f32 = tensorF32.ne[1].toInt()
+    val N_f32 = tensorF32.ne[0].toInt()
+
+    require(K_q41 == commonDimK) { "tensorQ41's fastest dim (ne[0]) $K_q41 must match commonDimK $commonDimK" }
+    require(K_f32 == commonDimK) { "tensorF32's second dim (ne[1]) $K_f32 must match commonDimK $commonDimK for KxN layout" }
+    require(rowIndexInQ41 < M_q41) { "rowIndexInQ41 $rowIndexInQ41 out of bounds for M $M_q41" }
+    require(colIndexInF32 < N_f32) { "colIndexInF32 $colIndexInF32 out of bounds for N $N_f32" }
+
+    var sumF32 = 0.0f
+
+    for (k in 0 until commonDimK) {
+        // Access element tensorQ41[rowIndexInQ41, k]
+        // Calculate flat index for Q4_1 tensor elements.
+        // tensorQ41.ne[0] is K (elements per row).
+        val flatIndexInQ41 = rowIndexInQ41 * K_q41 + k
+        val blockIndexQ41 = flatIndexInQ41 / QK4_1
+        val itemInBlockQ41 = flatIndexInQ41 % QK4_1
+
+        val scaleD = tensorQ41.getQ4_1BlockScale(graphAllocator, blockIndexQ41)
+        val minM = tensorQ41.getQ4_1BlockMin(graphAllocator, blockIndexQ41)
+        val qNibble = tensorQ41.getQ4_1NibbleWeight(graphAllocator, blockIndexQ41, itemInBlockQ41) // Returns raw nibble 0-15
+        val dequantizedQ41Value = scaleD * qNibble.toFloat() + minM // Dequantize Q4_1
+
+        // Access element tensorF32[k, colIndexInF32]
+        // tensorF32 is K rows (ne[1]) x N columns (ne[0]).
+        // GGMLTensor.getFloat expects (idx_dim0 which is column, idx_dim1 which is row, ...)
+        val f32Value = tensorF32.getFloat(graphAllocator, colIndexInF32, k)
+
+        sumF32 += dequantizedQ41Value * f32Value
+    }
+    return sumF32
+}
+
+/**
+ * Computes the dot product of a row from a Q4_0 tensor and a column from an F32 tensor.
+ */
+internal fun computeDotProductQ40F32(
+    graphAllocator: GGMLGraphAllocator,
+    tensorQ40: GGMLTensor,    // M x K (ne[0]=K, ne[1]=M)
+    tensorF32: GGMLTensor,    // K x N (ne[0]=N, ne[1]=K)
+    rowIndexInQ40: Int,
+    colIndexInF32: Int,
+    commonDimK: Int
+): Float {
+    require(tensorQ40.type == GGMLType.Q4_0) { "computeDotProductQ40F32: tensorQ40 must be Q4_0. Got ${tensorQ40.type}" }
+    require(tensorF32.type == GGMLType.F32) { "computeDotProductQ40F32: tensorF32 must be F32. Got ${tensorF32.type}" }
+    require(tensorQ40.ne[0].toInt() == commonDimK) { "tensorQ40 K dim (${tensorQ40.ne[0]}) must match commonDimK ($commonDimK)"}
+    require(tensorF32.ne[1].toInt() == commonDimK) { "tensorF32 K dim (${tensorF32.ne[1]}) must match commonDimK ($commonDimK)"}
+
+    var sumF32 = 0.0f
+    for (k in 0 until commonDimK) {
+        val flatIndexInQ40 = rowIndexInQ40 * commonDimK + k
+        val blockIndexQ40 = flatIndexInQ40 / QK4_0
+        val itemInBlockQ40 = flatIndexInQ40 % QK4_0
+        val scale = tensorQ40.getQ4_0BlockScale(graphAllocator, blockIndexQ40)
+        val qNibble = tensorQ40.getQ4_0NibbleWeight(graphAllocator, blockIndexQ40, itemInBlockQ40)
+        val dequantizedQ40Value = scale * (qNibble.toFloat() - 8.0f)
+        val f32Value = tensorF32.getFloat(graphAllocator, colIndexInF32, k)
+        sumF32 += dequantizedQ40Value * f32Value
+    }
+    return sumF32
+}
+
+// Helper to iterate N-dimensionally
+internal fun applyNDIter(tensor: GGMLTensor, totalSize: Int, actionPerElement: (flatIdx: Int, indices: IntArray) -> Unit) {
+    val n0 = tensor.ne[0].toInt(); val n1 = tensor.ne[1].toInt()
+    val n2 = tensor.ne[2].toInt(); val n3 = tensor.ne[3].toInt()
+    var currentFlatIdx = 0
+    if (totalSize == 0) return
+
+    val r = tensor.rank()
+    if (r == 0 && totalSize == 1) {
+        actionPerElement(currentFlatIdx++, intArrayOf()); return
+    }
+
+    for (i3 in 0 until (if (r >= 4) n3 else 1)) {
+        for (i2 in 0 until (if (r >= 3) n2 else 1)) {
+            for (i1 in 0 until (if (r >= 2) n1 else 1)) {
+                for (i0 in 0 until (if (r >= 1) n0 else 1)) {
+                    if (currentFlatIdx < totalSize) {
+                        val indices = when (r) {
+                            0 -> intArrayOf()
+                            1 -> intArrayOf(i0)
+                            2 -> intArrayOf(i0, i1)
+                            3 -> intArrayOf(i0, i1, i2)
+                            else -> intArrayOf(i0, i1, i2, i3)
+                        }
+                        actionPerElement(currentFlatIdx++, indices)
+                    } else return
+                }
+            }
+        }
+    }
+}
+
+/**
  * Adds two tensors element-wise.
- *
- * @param context The GGML context
- * @param a The first tensor
- * @param b The second tensor
- * @return The result tensor
  */
-fun computeAdd(@Suppress("unused") context: GGMLContext, a: GGMLTensor, b: GGMLTensor): GGMLTensor {
-    // Check that the tensors have compatible dimensions
+fun computeAdd(
+    graphAllocator: GGMLGraphAllocator,
+    @Suppress("unused") context: GGMLContext,
+    a: GGMLTensor,
+    b: GGMLTensor
+): GGMLTensor {
     for (i in 0 until GGML_MAX_DIMS) {
-        if (a.ne[i] != b.ne[i]) {
-            throw IllegalArgumentException("Incompatible dimensions for addition")
-        }
+        if (a.ne[i] != b.ne[i]) throw IllegalArgumentException("Incompatible dimensions for addition")
     }
+    val result = GGMLTensor(type = a.type); result.ne = a.ne.copyOf(); result.nb = a.nb.copyOf()
+    val totalSize = result.numElements().toInt()
 
-    // Create a new tensor for the result with the same dimensions as a
-    val result = GGMLTensor(type = a.type)
-    for (i in 0 until GGML_MAX_DIMS) {
-        result.ne[i] = a.ne[i]
-        result.nb[i] = a.nb[i]
-    }
-
-    // Calculate total size
-    val totalSize = calculateTotalSize(a.ne)
-
-    // Perform the addition based on the tensor type
     when (a.type) {
         GGMLType.F32 -> {
-            val aData = a.data as FloatArray
-            val bData = b.data as FloatArray
             val resultData = FloatArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = aData[j] + bData[j]
-                }
-                i = end
-            }
-
             result.data = resultData
+            applyNDIter(a, totalSize) { flatIdx, indices -> // Iterate based on 'a' which has same shape as result
+                val v0 = a.getFloat(graphAllocator, *indices)
+                val v1 = b.getFloat(graphAllocator, *indices)
+                resultData[flatIdx] = v0 + v1
+            }
         }
         GGMLType.F16 -> {
-            val aData = a.data as ShortArray
-            val bData = b.data as ShortArray
             val resultData = ShortArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    // Convert shorts to floats, add, then convert back to short
-                    val aFloat = aData[j].toFloat() / 32768.0f
-                    val bFloat = bData[j].toFloat() / 32768.0f
-                    val sum = aFloat + bFloat
-                    resultData[j] = (sum * 32768.0f).toInt().toShort()
-                }
-                i = end
-            }
-
             result.data = resultData
-        }
-        GGMLType.I8 -> {
-            val aData = a.data as ByteArray
-            val bData = b.data as ByteArray
-            val resultData = ByteArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = (aData[j] + bData[j]).toByte()
-                }
-                i = end
+            applyNDIter(a, totalSize) { flatIdx, indices -> // Iterate based on 'a'
+                val v0 = a.getHalf(graphAllocator, *indices)
+                val v1 = b.getHalf(graphAllocator, *indices)
+                // Perform addition as Float for precision, then convert back to Half (Short)
+                resultData[flatIdx] = floatToHalf(v0 + v1)
             }
-
-            result.data = resultData
-        }
-        GGMLType.I16 -> {
-            val aData = a.data as ShortArray
-            val bData = b.data as ShortArray
-            val resultData = ShortArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = (aData[j] + bData[j]).toShort()
-                }
-                i = end
-            }
-
-            result.data = resultData
         }
         GGMLType.I32 -> {
-            val aData = a.data as IntArray
-            val bData = b.data as IntArray
             val resultData = IntArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = aData[j] + bData[j]
-                }
-                i = end
-            }
-
             result.data = resultData
+            applyNDIter(a, totalSize) { flatIdx, indices ->
+                val valA = a.getInt(graphAllocator, *indices)
+                val valB = b.getInt(graphAllocator, *indices)
+                resultData[flatIdx] = valA + valB
+            }
+        }
+        GGMLType.I16 -> {
+            val resultData = ShortArray(totalSize)
+            result.data = resultData
+            applyNDIter(a, totalSize) { flatIdx, indices ->
+                val valA = a.getShort(graphAllocator, *indices).toInt()
+                val valB = b.getShort(graphAllocator, *indices).toInt()
+                resultData[flatIdx] = (valA + valB).coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+            }
+        }
+        GGMLType.I8 -> {
+            val resultData = ByteArray(totalSize)
+            result.data = resultData
+            applyNDIter(a, totalSize) { flatIdx, indices ->
+                val valA = a.getByte(graphAllocator, *indices).toInt()
+                val valB = b.getByte(graphAllocator, *indices).toInt()
+                resultData[flatIdx] = (valA + valB).coerceIn(Byte.MIN_VALUE.toInt(), Byte.MAX_VALUE.toInt()).toByte()
+            }
         }
         GGMLType.I64 -> {
-            val aData = a.data as LongArray
-            val bData = b.data as LongArray
             val resultData = LongArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = aData[j] + bData[j]
-                }
-                i = end
-            }
-
             result.data = resultData
+            applyNDIter(a, totalSize) { flatIdx, indices ->
+                val valA = a.getLong(graphAllocator, *indices)
+                val valB = b.getLong(graphAllocator, *indices)
+                resultData[flatIdx] = valA + valB
+            }
         }
         GGMLType.Q4_0, GGMLType.Q4_1, GGMLType.Q5_0, GGMLType.Q5_1, GGMLType.Q8_0, GGMLType.Q8_1 -> {
-            // Basic implementation for quantized types - dequantize, add, then requantize
-            // This is a placeholder and should be optimized in the future
-
-            // For now, we'll convert to F32, perform the operation, and convert back
-            // In a real implementation, we would have specialized code for each quantized type
-
-            // Create temporary F32 tensors
-            val aF32 = dequantizeTensor(a)
-            val bF32 = dequantizeTensor(b)
-
-            // Perform addition in F32
-            val resultF32 = computeAdd(context, aF32, bF32)
-
-            // Requantize to the original type
-            result.data = quantizeTensor(resultF32, a.type).data
+            val aF32 = dequantizeTensor(graphAllocator, a)
+            val bF32 = dequantizeTensor(graphAllocator, b)
+            val resultF32 = computeAdd(graphAllocator, context, aF32, bF32)
+            val quantizedResult = quantizeTensor(graphAllocator, resultF32, a.type)
+            result.data = quantizedResult.data
         }
-        else -> {
-            // For other types, we'll implement later
-            result.data = null
-        }
+        else -> throw NotImplementedError("computeAdd not implemented for type ${a.type}")
     }
-
     return result
 }
 
-/**
- * Dequantizes a tensor to F32 format.
- * This is a placeholder implementation that should be replaced with actual dequantization code.
- *
- * @param tensor The tensor to dequantize
- * @return A new tensor in F32 format
- */
-private fun dequantizeTensor(tensor: GGMLTensor): GGMLTensor {
-    // Create a new F32 tensor with the same dimensions
+fun computeMul(
+    graphAllocator: GGMLGraphAllocator,
+    @Suppress("unused") context: GGMLContext,
+    a: GGMLTensor,
+    b: GGMLTensor
+): GGMLTensor {
+    for (i in 0 until GGML_MAX_DIMS) {
+        if (a.ne[i] != b.ne[i]) throw IllegalArgumentException("Incompatible dimensions for multiplication")
+    }
+    val result = GGMLTensor(type = a.type); result.ne = a.ne.copyOf(); result.nb = a.nb.copyOf()
+    val totalSize = result.numElements().toInt()
+
+    when (a.type) {
+        GGMLType.F32 -> {
+            val resultData = FloatArray(totalSize)
+            result.data = resultData
+            applyNDIter(a, totalSize) { flatIdx, indices ->
+                val v0 = a.getFloat(graphAllocator, *indices)
+                val v1 = b.getFloat(graphAllocator, *indices)
+                resultData[flatIdx] = v0 * v1
+            }
+        }
+        GGMLType.F16 -> {
+            val resultData = ShortArray(totalSize)
+            result.data = resultData
+            applyNDIter(a, totalSize) { flatIdx, indices ->
+                val v0 = a.getHalf(graphAllocator, *indices)
+                val v1 = b.getHalf(graphAllocator, *indices)
+                resultData[flatIdx] = floatToHalf(v0 * v1)
+            }
+        }
+        GGMLType.I32 -> {
+            val resultData = IntArray(totalSize)
+            result.data = resultData
+            applyNDIter(a, totalSize) { flatIdx, indices ->
+                val valA = a.getInt(graphAllocator, *indices)
+                val valB = b.getInt(graphAllocator, *indices)
+                resultData[flatIdx] = valA * valB
+            }
+        }
+        GGMLType.I16 -> {
+            val resultData = ShortArray(totalSize)
+            result.data = resultData
+            applyNDIter(a, totalSize) { flatIdx, indices ->
+                val valA = a.getShort(graphAllocator, *indices).toInt()
+                val valB = b.getShort(graphAllocator, *indices).toInt()
+                resultData[flatIdx] = (valA * valB).coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+            }
+        }
+        GGMLType.I8 -> {
+            val resultData = ByteArray(totalSize)
+            result.data = resultData
+            applyNDIter(a, totalSize) { flatIdx, indices ->
+                val valA = a.getByte(graphAllocator, *indices).toInt()
+                val valB = b.getByte(graphAllocator, *indices).toInt()
+                resultData[flatIdx] = (valA * valB).coerceIn(Byte.MIN_VALUE.toInt(), Byte.MAX_VALUE.toInt()).toByte()
+            }
+        }
+        GGMLType.I64 -> {
+            val resultData = LongArray(totalSize)
+            result.data = resultData
+            applyNDIter(a, totalSize) { flatIdx, indices ->
+                val valA = a.getLong(graphAllocator, *indices)
+                val valB = b.getLong(graphAllocator, *indices)
+                resultData[flatIdx] = valA * valB
+            }
+        }
+        GGMLType.Q4_0, GGMLType.Q4_1, GGMLType.Q5_0, GGMLType.Q5_1, GGMLType.Q8_0, GGMLType.Q8_1 -> {
+            val aF32 = dequantizeTensor(graphAllocator, a)
+            val bF32 = dequantizeTensor(graphAllocator, b)
+            val resultF32 = computeMul(graphAllocator, context, aF32, bF32)
+            val quantizedResult = quantizeTensor(graphAllocator, resultF32, a.type)
+            result.data = quantizedResult.data
+        }
+        else -> throw NotImplementedError("computeMul not implemented for type ${a.type}")
+    }
+    return result
+}
+
+private fun dequantizeTensor(graphAllocator: GGMLGraphAllocator, tensor: GGMLTensor): GGMLTensor {
     val result = GGMLTensor(type = GGMLType.F32)
-    for (i in 0 until GGML_MAX_DIMS) {
-        result.ne[i] = tensor.ne[i]
+    result.ne = tensor.ne.copyOf()
+    if (result.type.byteSize > 0uL) {
+        result.nb[0] = result.type.byteSize
+        for (d in 1 until GGML_MAX_DIMS) { result.nb[d] = result.ne[d-1].toULong() * result.nb[d-1] }
+    } else {
+        for(d in 0 until GGML_MAX_DIMS) result.nb[d] = 0uL
     }
+    val numElements = tensor.numElements().toInt()
+    val resultDataArray = FloatArray(numElements)
+    when (tensor.type) {
+        GGMLType.F16 -> applyNDIter(tensor, numElements) { flatIdx, indices -> if (flatIdx < numElements) resultDataArray[flatIdx] = tensor.getHalf(graphAllocator, *indices) }
+        GGMLType.F32 -> applyNDIter(tensor, numElements) { flatIdx, indices -> if (flatIdx < numElements) resultDataArray[flatIdx] = tensor.getFloat(graphAllocator, *indices) }
+        GGMLType.Q8_0 -> {
+            val numBlocks = tensor.getNumBlocks().toInt(); var fidx = 0
+            for (blockIdx in 0 until numBlocks) {
+                val scale = tensor.getQ8_0BlockScale(graphAllocator, blockIdx)
+                for (itemIdxInBlock in 0 until QK8_0) { if (fidx < numElements) resultDataArray[fidx++] = scale * tensor.getQ8_0Weight(graphAllocator, blockIdx, itemIdxInBlock).toFloat() else break }
+                if (fidx >= numElements && blockIdx < numBlocks -1) { println("Warn: Q8_0 dequant filled array early for ${tensor.name}"); break }
+            }
+            if (fidx != numElements && numElements > 0) println("Warn: Q8_0 dequant element count mismatch for ${tensor.name}: $fidx vs $numElements")
+        }
+        GGMLType.Q4_0 -> {
+            val numBlocks = tensor.getNumBlocks().toInt(); var fidx = 0
+            for (blockIdx in 0 until numBlocks) {
+                val scale = tensor.getQ4_0BlockScale(graphAllocator, blockIdx)
+                for (itemIdxInBlock in 0 until QK4_0) { if (fidx < numElements) resultDataArray[fidx++] = scale * (tensor.getQ4_0NibbleWeight(graphAllocator, blockIdx, itemIdxInBlock).toFloat() - 8.0f) else break }
+                if (fidx >= numElements && blockIdx < numBlocks -1) { println("Warn: Q4_0 dequant filled array early for ${tensor.name}"); break }
+            }
+             if (fidx != numElements && numElements > 0) println("Warn: Q4_0 dequant element count mismatch for ${tensor.name}: $fidx vs $numElements")
+        }
+        GGMLType.Q4_1 -> {
+            val numBlocks = tensor.getNumBlocks().toInt(); var fidx = 0
+            for (blockIdx in 0 until numBlocks) {
+                val dScale = tensor.getQ4_1BlockScale(graphAllocator, blockIdx)
+                val mMin = tensor.getQ4_1BlockMin(graphAllocator, blockIdx)
+                for (itemIdxInBlock in 0 until QK4_1) {
+                    if (fidx < numElements) {
+                        val qNibble = tensor.getQ4_1NibbleWeight(graphAllocator, blockIdx, itemIdxInBlock)
+                        resultDataArray[fidx++] = dScale * qNibble.toFloat() + mMin
+                    } else { if(fidx > 0) println("Warn: Q4_1 dequant read past numElements for ${tensor.name}"); break }
+                }
+                if (fidx >= numElements && blockIdx < numBlocks -1) { println("Warn: Q4_1 dequant filled array early for ${tensor.name}"); break }
+            }
+            if (fidx != numElements && numElements > 0) println("Warn: Q4_1 dequant element count mismatch for ${tensor.name}: $fidx vs $numElements")
+        }
+        else -> println("Warning: dequantizeTensor from ${tensor.type} to F32 not fully implemented. Result is zeroed for ${tensor.name}.")
+    }
+    result.data = resultDataArray; return result
+}
 
-    // Calculate total size
-    val totalSize = calculateTotalSize(tensor.ne)
+private fun quantizeTensor(graphAllocator: GGMLGraphAllocator, tensorF32: GGMLTensor, targetType: GGMLType): GGMLTensor {
+    if (tensorF32.type != GGMLType.F32) throw IllegalArgumentException("quantizeTensor expects F32 input, got ${tensorF32.type}")
+    val result = GGMLTensor(type = targetType); result.ne = tensorF32.ne.copyOf()
+    if (targetType.byteSize > 0uL) {
+        result.nb[0] = targetType.byteSize
+        for (d in 1 until GGML_MAX_DIMS) { result.nb[d] = result.ne[d-1].toULong() * result.nb[d-1] }
+    } else {
+        if (targetType != GGMLType.COUNT && !targetType.description.startsWith("Q", ignoreCase = true)) println("Warn: Stride calc for ${targetType.name} in quantizeTensor may be incomplete.")
+        for(d in 0 until GGML_MAX_DIMS) result.nb[d] = 0uL
+    }
+    val numElements = tensorF32.numElements().toInt()
+    when (targetType) {
+        GGMLType.F16 -> {
+            val resArr = ShortArray(numElements); applyNDIter(tensorF32, numElements) { fid, ind -> if (fid < numElements) resArr[fid] = floatToHalf(tensorF32.getFloat(graphAllocator, *ind)) }; result.data = resArr
+        }
+        GGMLType.F32 -> {
+            val resArr = FloatArray(numElements); applyNDIter(tensorF32, numElements) { fid, ind -> if (fid < numElements) resArr[fid] = tensorF32.getFloat(graphAllocator, *ind) }; result.data = resArr
+        }
+        GGMLType.Q8_0 -> {
+            require(numElements % QK8_0 == 0) { "Q8_0 numElements $numElements not div by $QK8_0" }
+            val nBlk = numElements / QK8_0; val blkSize = targetType.byteSize.toInt(); require(blkSize == SHORT_SIZE_BYTES + QK8_0) { "Q8_0 block size mismatch" }
+            val resArr = ByteArray(nBlk * blkSize); val f32Blk = FloatArray(QK8_0); var curIdx = 0; var boff = 0
+            applyNDIter(tensorF32, numElements) { _, ind ->
+                val itemInBlk = curIdx % QK8_0; f32Blk[itemInBlk] = tensorF32.getFloat(graphAllocator, *ind)
+                if (itemInBlk == QK8_0 - 1) {
+                    var amax = 0.0f; for (v in f32Blk) amax = maxOf(amax, abs(v)); val scale = if (amax == 0.0f) 1.0f else amax / 127.0f; val invS = 1.0f / scale
+                    resArr.setShortLe(boff, floatToHalf(scale)); val qOff = boff + SHORT_SIZE_BYTES
+                    for (k in 0 until QK8_0) resArr[qOff + k] = round(f32Blk[k] * invS).toInt().coerceIn(-128, 127).toByte()
+                    boff += blkSize
+                }; curIdx++
+            }; result.data = resArr
+        }
+        GGMLType.Q4_0 -> {
+            require(numElements % QK4_0 == 0) { "Q4_0 numElements $numElements not div by $QK4_0" }
+            val nBlk = numElements / QK4_0; val blkSize = targetType.byteSize.toInt(); require(blkSize == SHORT_SIZE_BYTES + QK4_0 / 2) { "Q4_0 block size mismatch" }
+            val resArr = ByteArray(nBlk * blkSize); val f32Blk = FloatArray(QK4_0); var curIdx = 0; var boff = 0
+            applyNDIter(tensorF32, numElements) { _, ind ->
+                val itemInBlk = curIdx % QK4_0; f32Blk[itemInBlk] = tensorF32.getFloat(graphAllocator, *ind)
+                if (itemInBlk == QK4_0 - 1) {
+                    var amax = 0.0f; for (v in f32Blk) amax = maxOf(amax, abs(v)); val scale = if (amax == 0.0f) 1.0f else amax / 8.0f; val invS = if (scale == 0.0f) 0.0f else 1.0f / scale
+                    resArr.setShortLe(boff, floatToHalf(scale)); val qOff = boff + SHORT_SIZE_BYTES
+                    for (j in 0 until QK4_0 / 2) {
+                        val q1 = round(f32Blk[j*2] * invS + 8.0f).toInt().coerceIn(0,15); val q2 = round(f32Blk[j*2+1] * invS + 8.0f).toInt().coerceIn(0,15)
+                        resArr[qOff + j] = ((q1 and 0x0F) or ((q2 and 0x0F) shl 4)).toByte()
+                    }; boff += blkSize
+                }; curIdx++
+            }; result.data = resArr
+        }
+        GGMLType.Q8_1 -> { result.data = ByteArray(numElements); println("Warn: Quant F32 to ${targetType.name} NI") }
+        GGMLType.Q4_1 -> {
+            require(tensorF32.type == GGMLType.F32) { "Input tensor for Q4_1 quantization must be F32. Got ${tensorF32.type}" } // Already checked at function start, but good for clarity
+            require(numElements % QK4_1 == 0) { "For Q4_1 quantization, total elements ($numElements) must be divisible by QK4_1 ($QK4_1)" }
 
-    // Allocate memory for the result
-    result.data = FloatArray(totalSize)
+            val numBlocks = numElements / QK4_1
+            val q4_1BlockByteSize = targetType.byteSize.toInt()
+            val expectedBlockSize = (2 * SHORT_SIZE_BYTES) + (QK4_1 / 2)
+            require(q4_1BlockByteSize == expectedBlockSize) { "Q4_1 block byte size mismatch. Expected $expectedBlockSize, got $q4_1BlockByteSize. Type says: ${targetType.byteSize}" }
 
-    // For now, just return a zero-filled tensor
-    // In a real implementation, we would dequantize based on the tensor type
+            val q4_1DataArray = ByteArray(numBlocks * q4_1BlockByteSize)
+            result.data = q4_1DataArray // Assign the data array to the result tensor prepared at the start of the function
 
+            val f32BlockValues = FloatArray(QK4_1)
+            var currentF32ElementIndex = 0
+            var q4_1ByteArrayWriteOffset = 0
+
+            // Iterate through blocks by sequentially filling f32BlockValues
+            for (blockNum in 0 until numBlocks) {
+                // Populate f32BlockValues for the current block
+                // This assumes tensorF32.data is a FloatArray and elements are contiguous.
+                // A more robust way would use tensorF32.getFloat(graphAllocator, indices) via applyNDIter,
+                // but that might be slower if direct array access is safe and possible.
+                // For now, let's use a simplified sequential access matching applyNDIter's typical order.
+                // This part needs careful review if tensorF32 data isn't flat or directly accessible.
+                // The applyNDIter in other quantization paths fetches element by element.
+
+                // Simplified block population:
+                var f32BlockReadCount = 0
+                applyNDIter(tensorF32, numElements) { flatIdx, indices ->
+                    if (flatIdx >= blockNum * QK4_1 && flatIdx < (blockNum + 1) * QK4_1) {
+                        if (f32BlockReadCount < QK4_1) { // Ensure we don't write out of bounds
+                           f32BlockValues[f32BlockReadCount++] = tensorF32.getFloat(graphAllocator, *indices)
+                        }
+                    }
+                }
+                // Ensure the block was fully read if applyNDIter was used in this fashion
+                // This simplified block population is complex. A direct iteration is better.
+                // Let's refine the block population strategy.
+
+                // Refined block population:
+                // We need to ensure that we are picking elements from tensorF32 in their logical order.
+                // applyNDIter provides flatIdx and multi-dim indices. We can use flatIdx.
+                // The outer loop is `for (blockNum in 0 until numBlocks)`.
+                // The `currentF32ElementIndex` will track our position in the flat F32 data.
+                // This will be simpler than trying to make applyNDIter fill just one block at a time.
+
+                for (i in 0 until QK4_1) {
+                    // This assumes getFloat can handle a flat index or we convert blockNum*QK4_1 + i to ND-indices.
+                    // Given applyNDIter exists, it's better to use it once over all elements
+                    // and then process them in blocks, as done for Q8_0 and Q4_0.
+                    // The current structure with applyNDIter outside the block loop is for those.
+                    // Replicating that for Q4_1:
+                    // We need to collect QK4_1 elements per block.
+                    // The existing Q8_0/Q4_0 loops use applyNDIter ONCE and process blocks inside its lambda.
+                    // Let's adapt that pattern.
+                    // This means the 'result.data = q4_1DataArray' should be inside this when case.
+                    // And the loop structure will be similar to Q8_0/Q4_0.
+                    // The 'result' tensor is already set up with type and ne. Strides also.
+                    // So, the previous structure of Q8_0/Q4_0 is:
+                    // val resArr = ByteArray(nBlk * blkSize)
+                    // val f32Blk = FloatArray(QK_K)
+                    // var curIdx = 0 (overall element index)
+                    // var boff = 0 (byte offset in resArr)
+                    // applyNDIter(tensorF32, numElements) { _, ind ->
+                    //    val itemInBlk = curIdx % QK_K; f32Blk[itemInBlk] = tensorF32.getFloat(graphAllocator, *ind)
+                    //    if (itemInBlk == QK_K - 1) { process block }
+                    //    curIdx++
+                    // }
+                    // result.data = resArr
+                    // This is the pattern to follow.
+                }
+            }
+            // --- Re-writing the loop structure based on Q8_0/Q4_0 pattern ---
+            val f32BlockBuffer = FloatArray(QK4_1) // Temporary buffer for one block of F32 values
+            var currentElementInF32 = 0
+            var byteArrayWriteOffset = 0
+
+            applyNDIter(tensorF32, numElements) { _, indices ->
+                val itemInBlockIndex = currentElementInF32 % QK4_1
+                f32BlockBuffer[itemInBlockIndex] = tensorF32.getFloat(graphAllocator, *indices)
+
+                if (itemInBlockIndex == QK4_1 - 1) { // Block is full, process it
+                    val f_min = f32BlockBuffer.minOrNull() ?: 0.0f
+                    val f_max = f32BlockBuffer.maxOrNull() ?: 0.0f
+
+                    var d_scaleF32 = (f_max - f_min) / 15.0f
+                    if (d_scaleF32 == 0.0f) { // Handles case where f_max == f_min
+                        d_scaleF32 = 1.0f
+                    }
+                    val m_minF32 = f_min
+                    // invDScaleF32 is guaranteed to be valid as d_scaleF32 is non-zero.
+                    val invDScaleF32 = 1.0f / d_scaleF32
+
+                    val d_scaleF16Short = floatToHalf(d_scaleF32)
+                    val m_minF16Short = floatToHalf(m_minF32)
+
+                    q4_1DataArray.setShortLe(byteArrayWriteOffset, d_scaleF16Short)
+                    q4_1DataArray.setShortLe(byteArrayWriteOffset + SHORT_SIZE_BYTES, m_minF16Short)
+
+                    val qsDataWriteStartOffsetInBlock = byteArrayWriteOffset + (2 * SHORT_SIZE_BYTES)
+                    for (j in 0 until QK4_1 / 2) {
+                        val f32Val1 = f32BlockBuffer[j * 2]
+                        val f32Val2 = f32BlockBuffer[j * 2 + 1]
+
+                        val quantVal1 = round((f32Val1 - m_minF32) * invDScaleF32).toInt().coerceIn(0, 15)
+                        val quantVal2 = round((f32Val2 - m_minF32) * invDScaleF32).toInt().coerceIn(0, 15)
+
+                        val packedByte = (quantVal1 and 0x0F) or ((quantVal2 and 0x0F) shl 4)
+                        q4_1DataArray[qsDataWriteStartOffsetInBlock + j] = packedByte.toByte()
+                    }
+                    byteArrayWriteOffset += q4_1BlockByteSize
+                }
+                currentElementInF32++
+            }
+            result.data = q4_1DataArray
+        }
+        GGMLType.Q5_0, GGMLType.Q5_1 -> { result.data = ByteArray((numElements * 5 + 7) / 8); println("Warn: Quant F32 to ${targetType.name} NI") }
+        else -> { println("Error: Unsupp target quant type $targetType"); result.data = null }
+    }
     return result
 }
 
-/**
- * Quantizes a F32 tensor to the specified type.
- * This is a placeholder implementation that should be replaced with actual quantization code.
- *
- * @param tensor The F32 tensor to quantize
- * @param type The target quantization type
- * @return A new tensor in the specified quantized format
- */
-private fun quantizeTensor(tensor: GGMLTensor, type: GGMLType): GGMLTensor {
-    // Create a new tensor with the specified type and same dimensions
-    val result = GGMLTensor(type = type)
-    for (i in 0 until GGML_MAX_DIMS) {
-        result.ne[i] = tensor.ne[i]
+fun computeMatMul(graphAllocator: GGMLGraphAllocator, @Suppress("unused") context: GGMLContext, a: GGMLTensor, b: GGMLTensor): GGMLTensor {
+    val M = a.ne[1].toInt()
+    val K_a = a.ne[0].toInt()
+    val N = b.ne[0].toInt()
+    val K_b = b.ne[1].toInt()
+    if (K_a != K_b) throw IllegalArgumentException("Dim mismatch K: a.ne[0]($K_a) != b.ne[1]($K_b)")
+    val K = K_a
+
+    if (a.type == GGMLType.Q4_0 && b.type == GGMLType.F32) {
+        val result = GGMLTensor(GGMLType.F32); result.ne = longArrayOf(N.toLong(), M.toLong(), 1L, 1L)
+        for(i_dim in 2 until GGML_MAX_DIMS) { val neA=a.ne.getOrElse(i_dim){1L}; val neB=b.ne.getOrElse(i_dim){1L}; result.ne[i_dim]=maxOf(neA,neB); if(!(neA==neB || neA==1L || neB==1L)) throw IllegalArgumentException("Matmul broadcast fail dim $i_dim: ${a.ne[i_dim]} vs ${b.ne[i_dim]}") }
+        result.nb[0]=result.type.byteSize; for(d in 1 until GGML_MAX_DIMS){result.nb[d]=result.ne.getOrElse(d-1){1L}.toULong()*result.nb[d-1]}
+        val resArr=FloatArray(M*N); result.data=resArr; var flatIdx=0
+        for(i in 0 until M){ for(j in 0 until N){ resArr[flatIdx++]=computeDotProductQ40F32(graphAllocator,a,b,i,j,K) } }
+        return result
+    }
+    if (a.type == GGMLType.Q4_1 && b.type == GGMLType.F32) {
+        // Optimized Q4_1 x F32 path, result is F32
+        // a (src0) is M x K (ne[1]=M rows, ne[0]=K cols for element access)
+        // b (src1) is K x N (ne[1]=K rows, ne[0]=N cols for element access)
+        // Result will be M x N (ne[1]=M rows, ne[0]=N cols)
+
+        // Note: M, K_a, N, K_b, K are already defined at the start of computeMatMul
+        // val M = a.ne[1].toInt() // Already available
+        // val K_a = a.ne[0].toInt() // Already available
+        // val K_b = b.ne[1].toInt() // Already available
+        // val N = b.ne[0].toInt()   // Already available
+        // val K = K_a // Already available and validated K_a == K_b
+
+        // Create result tensor (F32, M rows, N columns)
+        // The ne array for new tensor: [N_cols, M_rows, 1, 1]
+        val resultNe = longArrayOf(N.toLong(), M.toLong(), 1L, 1L)
+        // Handle broadcasting for dimensions 2 and 3 if necessary, like other paths
+        for(i_dim in 2 until GGML_MAX_DIMS) {
+            val neA = a.ne.getOrElse(i_dim){1L}
+            val neB = b.ne.getOrElse(i_dim){1L}
+            resultNe[i_dim] = maxOf(neA, neB)
+            if(!(neA == neB || neA == 1L || neB == 1L)) {
+                throw IllegalArgumentException("Matmul broadcast fail for Q4_1xF32 on dim $i_dim: ${a.ne[i_dim]} vs ${b.ne[i_dim]}")
+            }
+        }
+        val result = GGMLTensor(GGMLType.F32, resultNe)
+
+        // Calculate and set strides for result tensor
+        result.nb[0] = result.type.byteSize
+        for (d in 1 until GGML_MAX_DIMS) {
+            result.nb[d] = result.ne.getOrElse(d-1) { 1L }.toULong() * result.nb[d-1]
+        }
+
+        val resultArray = FloatArray(M * N * resultNe[2].toInt() * resultNe[3].toInt()) // Adjusted for potential broadcasted dims
+        result.data = resultArray
+
+        // TODO: Handle broadcasting for dims 2 and 3 in the loops if resultNe[2] or resultNe[3] > 1.
+        // For now, assuming non-broadcasted higher dims (or handled by dot product if it supports it, which it doesn't directly)
+        // The current Q4_0/Q8_0 paths also don't explicitly show broadcasting in their loops but set up result.ne correctly.
+        // This implies the dot product functions are called for each "slice" or the structure expects M*N iterations flatly.
+        // Let's match the existing Q4_0/Q8_0 structure which assumes M*N iterations for the primary 2D matrix part.
+        // If higher dims were broadcasted, M and N would need to be multiplied by those dimensions for total iterations.
+        // The current structure of M*N iterations for the result array is for a single 2D plane.
+        // If resultNe[2]*resultNe[3] > 1, the flat idx logic needs to be aware or the loops need to be nested.
+        // The existing paths (Q4_0, Q8_0) use a simple M*N loop and flatIdx for resArr.
+        // This suggests that for these specific optimized paths, broadcasting in higher dimensions might not be fully handled
+        // or is implicitly handled by the calling context if these are part of larger ops.
+        // For now, sticking to the M*N loop for the primary matrix plane.
+
+        var idx = 0 // Index for flat resultArray
+        for (i in 0 until M) { // Iterate output rows (M)
+            for (j in 0 until N) { // Iterate output columns (N)
+                // This assumes a, b are effectively 2D for the dot product part.
+                // If a or b have higher dimensions that are not 1, computeDotProductQ41F32 needs to handle it,
+                // or this loop structure needs to be more complex to iterate over those dimensions.
+                // The current dot product functions take simple row/col indices.
+                val dotProduct = computeDotProductQ41F32(
+                    graphAllocator,
+                    a,    // Q4_1 tensor (src0)
+                    b,    // F32 tensor (src1)
+                    i,    // Current row in src0 (0 to M-1)
+                    j,    // Current column in src1 (0 to N-1)
+                    K     // Common dimension
+                )
+                resultArray[idx++] = dotProduct
+            }
+        }
+        return result
+    }
+    if (a.type == GGMLType.Q8_0 && b.type == GGMLType.F32) {
+        val result = GGMLTensor(GGMLType.F32); result.ne = longArrayOf(N.toLong(), M.toLong(), 1L, 1L)
+        for(i_dim in 2 until GGML_MAX_DIMS) { val neA=a.ne.getOrElse(i_dim){1L}; val neB=b.ne.getOrElse(i_dim){1L}; result.ne[i_dim]=maxOf(neA,neB); if(!(neA==neB || neA==1L || neB==1L)) throw IllegalArgumentException("Matmul broadcast fail dim $i_dim: ${a.ne[i_dim]} vs ${b.ne[i_dim]}") }
+        result.nb[0]=result.type.byteSize; for(d in 1 until GGML_MAX_DIMS){result.nb[d]=result.ne.getOrElse(d-1){1L}.toULong()*result.nb[d-1]}
+        val resArr=FloatArray(M*N); result.data=resArr; var flatIdx=0
+        for(i in 0 until M){ for(j in 0 until N){ resArr[flatIdx++]=computeDotProductQ80F32(graphAllocator,a,b,i,j,K) } }
+        return result
     }
 
-    // Calculate total size
-    val totalSize = calculateTotalSize(tensor.ne)
+    val resultTensor=GGMLTensor(type=a.type); resultTensor.ne=longArrayOf(N.toLong(),M.toLong(),1,1)
+    for(i_dim in 2 until GGML_MAX_DIMS){ val neA=a.ne.getOrElse(i_dim){1L}; val neB=b.ne.getOrElse(i_dim){1L}; resultTensor.ne[i_dim]=maxOf(neA,neB); if(!(neA==neB || neA==1L || neB==1L)) throw IllegalArgumentException("Matmul broadcast fail dim $i_dim: ${a.ne[i_dim]} vs ${b.ne[i_dim]}") }
+    if(resultTensor.type.byteSize>0uL){ resultTensor.nb[0]=resultTensor.type.byteSize; for(d in 1 until GGML_MAX_DIMS){resultTensor.nb[d]=resultTensor.ne[d-1].toULong()*resultTensor.nb[d-1]} } else {for(d in 0 until GGML_MAX_DIMS)resultTensor.nb[d]=0uL}
 
-    // Allocate memory for the result based on the type
-    when (type) {
-        GGMLType.Q4_0, GGMLType.Q4_1 -> {
-            // 4-bit quantization - each byte stores 2 values
-            result.data = ByteArray((totalSize + 1) / 2)
-        }
-        GGMLType.Q5_0, GGMLType.Q5_1 -> {
-            // 5-bit quantization - more complex packing
-            result.data = ByteArray((totalSize * 5 + 7) / 8)
-        }
-        GGMLType.Q8_0, GGMLType.Q8_1 -> {
-            // 8-bit quantization - one byte per value
-            result.data = ByteArray(totalSize)
-        }
-        else -> {
-            // Should not happen
-            result.data = null
-        }
-    }
-
-    // For now, just return a zero-filled tensor
-    // In a real implementation, we would quantize based on the tensor type
-
-    return result
-}
-
-/**
- * Multiplies two tensors element-wise.
- *
- * @param context The GGML context
- * @param a The first tensor
- * @param b The second tensor
- * @return The result tensor
- */
-fun computeMul(@Suppress("unused") context: GGMLContext, a: GGMLTensor, b: GGMLTensor): GGMLTensor {
-    // Check that the tensors have compatible dimensions
-    for (i in 0 until GGML_MAX_DIMS) {
-        if (a.ne[i] != b.ne[i]) {
-            throw IllegalArgumentException("Incompatible dimensions for multiplication")
-        }
-    }
-
-    // Create a new tensor for the result with the same dimensions as a
-    val result = GGMLTensor(type = a.type)
-    for (i in 0 until GGML_MAX_DIMS) {
-        result.ne[i] = a.ne[i]
-        result.nb[i] = a.nb[i]
-    }
-
-    // Calculate total size
-    val totalSize = calculateTotalSize(a.ne)
-
-    // Perform the multiplication based on the tensor type
     when (a.type) {
         GGMLType.F32 -> {
-            val aData = a.data as FloatArray
-            val bData = b.data as FloatArray
-            val resultData = FloatArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = aData[j] * bData[j]
-                }
-                i = end
-            }
-
-            result.data = resultData
+            val effA=a; val effB=if(b.type==GGMLType.F32)b else dequantizeTensor(graphAllocator,b)
+            val resArr = FloatArray(M*N); resultTensor.data=resArr; resultTensor.type = GGMLType.F32; var flatIdx=0
+            for(i in 0 until M){for(j in 0 until N){var sum=0.0f; for(l in 0 until K){sum+=effA.getFloat(graphAllocator,l,i)*effB.getFloat(graphAllocator,j,l)}; resArr[flatIdx++]=sum}}
         }
         GGMLType.F16 -> {
-            val aData = a.data as ShortArray
-            val bData = b.data as ShortArray
-            val resultData = ShortArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    // Convert shorts to floats, multiply, then convert back to short
-                    val aFloat = aData[j].toFloat() / 32768.0f
-                    val bFloat = bData[j].toFloat() / 32768.0f
-                    val product = aFloat * bFloat
-                    resultData[j] = (product * 32768.0f).toInt().toShort()
-                }
-                i = end
-            }
-
-            result.data = resultData
+            val effA=a; val effB=if(b.type==GGMLType.F16)b else dequantizeTensor(graphAllocator,b)
+            if(effB.type!=GGMLType.F16) throw NotImplementedError("F16xnon-F16 matmul to F16 NI")
+            val resArr = ShortArray(M*N); resultTensor.data=resArr; var flatIdx=0
+            for(i in 0 until M){for(j in 0 until N){var sum=0.0f; for(l in 0 until K){sum+=effA.getHalf(graphAllocator,l,i)*effB.getHalf(graphAllocator,j,l)}; resArr[flatIdx++]=floatToHalf(sum)}}
         }
-        GGMLType.I8 -> {
-            val aData = a.data as ByteArray
-            val bData = b.data as ByteArray
-            val resultData = ByteArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = (aData[j] * bData[j]).toByte()
-                }
-                i = end
-            }
-
-            result.data = resultData
+        GGMLType.Q4_0,GGMLType.Q4_1,GGMLType.Q5_0,GGMLType.Q5_1,GGMLType.Q8_0,GGMLType.Q8_1 -> {
+            val aF32=dequantizeTensor(graphAllocator,a); val bF32=dequantizeTensor(graphAllocator,b)
+            val resF32=computeMatMul(graphAllocator,context,aF32,bF32)
+            val qRes=quantizeTensor(graphAllocator,resF32,resultTensor.type); resultTensor.data=qRes.data
         }
-        GGMLType.I16 -> {
-            val aData = a.data as ShortArray
-            val bData = b.data as ShortArray
-            val resultData = ShortArray(totalSize)
+        else -> throw NotImplementedError("computeMatMul NI for input type ${a.type}")
+    }
+    return resultTensor
+}
 
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = (aData[j] * bData[j]).toShort()
-                }
-                i = end
-            }
+fun computeRelu(graphAllocator: GGMLGraphAllocator, @Suppress("unused") context: GGMLContext, a: GGMLTensor): GGMLTensor {
+    val result = GGMLTensor(type = a.type); result.ne = a.ne.copyOf(); result.nb = a.nb.copyOf()
+    val totalSize = result.numElements().toInt()
+    when (a.type) {
+        GGMLType.F32 -> applyNDIter(result, totalSize) { _, ind -> result.setFloat(graphAllocator, if(a.getFloat(graphAllocator, *ind)>0.0f)a.getFloat(graphAllocator,*ind)else 0.0f, *ind) }
+        GGMLType.F16 -> applyNDIter(result, totalSize) { _, ind -> result.setHalf(graphAllocator, if(a.getHalf(graphAllocator, *ind)>0.0f)a.getHalf(graphAllocator,*ind)else 0.0f, *ind) }
+        else -> throw NotImplementedError("computeRelu NI for type ${a.type}")
+    }
+    return result
+}
 
-            result.data = resultData
+fun computeGelu(graphAllocator: GGMLGraphAllocator, @Suppress("unused") context: GGMLContext, a: GGMLTensor): GGMLTensor {
+    val result = GGMLTensor(type = a.type); result.ne = a.ne.copyOf(); result.nb = a.nb.copyOf()
+    val totalSize = result.numElements().toInt()
+    val gelu = {x:Float -> x*0.5f*(1.0f+kotlin.math.tanh(0.797885f*(x+0.044715f*x*x*x)))}
+    when (a.type) {
+        GGMLType.F32 -> applyNDIter(result, totalSize) { _, ind -> result.setFloat(graphAllocator, gelu(a.getFloat(graphAllocator, *ind)), *ind) }
+        GGMLType.F16 -> applyNDIter(result, totalSize) { _, ind -> result.setHalf(graphAllocator, gelu(a.getHalf(graphAllocator, *ind)), *ind) }
+        else -> throw NotImplementedError("computeGelu NI for type ${a.type}")
+    }
+    return result
+}
+
+fun computeSub(graphAllocator: GGMLGraphAllocator, @Suppress("unused") context: GGMLContext, a: GGMLTensor, b: GGMLTensor): GGMLTensor {
+    for(i in 0 until GGML_MAX_DIMS){if(a.ne[i]!=b.ne[i])throw IllegalArgumentException("Dims mismatch")}
+    val res=GGMLTensor(a.type); res.ne=a.ne.copyOf(); res.nb=a.nb.copyOf(); val ts=res.numElements().toInt()
+    when(a.type){
+        GGMLType.F32-> {
+            val resultData = FloatArray(ts); res.data = resultData
+            applyNDIter(a,ts){flatIdx,ind->resultData[flatIdx] = a.getFloat(graphAllocator,*ind)-b.getFloat(graphAllocator,*ind)}
+        }
+        GGMLType.F16-> {
+            val resultData = ShortArray(ts); res.data = resultData
+            applyNDIter(a,ts){flatIdx,ind->resultData[flatIdx] = floatToHalf(a.getHalf(graphAllocator,*ind)-b.getHalf(graphAllocator,*ind))}
         }
         GGMLType.I32 -> {
-            val aData = a.data as IntArray
-            val bData = b.data as IntArray
-            val resultData = IntArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = aData[j] * bData[j]
-                }
-                i = end
+            val resultData = IntArray(ts); res.data = resultData
+            applyNDIter(a, ts) { flatIdx, indices ->
+                resultData[flatIdx] = a.getInt(graphAllocator, *indices) - b.getInt(graphAllocator, *indices)
             }
-
-            result.data = resultData
-        }
-        GGMLType.I64 -> {
-            val aData = a.data as LongArray
-            val bData = b.data as LongArray
-            val resultData = LongArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = aData[j] * bData[j]
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.Q4_0, GGMLType.Q4_1, GGMLType.Q5_0, GGMLType.Q5_1, GGMLType.Q8_0, GGMLType.Q8_1 -> {
-            // Basic implementation for quantized types - dequantize, multiply, then requantize
-            // This is a placeholder and should be optimized in the future
-
-            // For now, we'll convert to F32, perform the operation, and convert back
-            // In a real implementation, we would have specialized code for each quantized type
-
-            // Create temporary F32 tensors
-            val aF32 = dequantizeTensor(a)
-            val bF32 = dequantizeTensor(b)
-
-            // Perform multiplication in F32
-            val resultF32 = computeMul(context, aF32, bF32)
-
-            // Requantize to the original type
-            result.data = quantizeTensor(resultF32, a.type).data
-        }
-        else -> {
-            // For other types, we'll implement later
-            result.data = null
-        }
-    }
-
-    return result
-}
-
-/**
- * Performs matrix multiplication of two tensors.
- *
- * @param context The GGML context
- * @param a The first tensor (m x n)
- * @param b The second tensor (n x p)
- * @return The result tensor (m x p)
- */
-fun computeMatMul(@Suppress("unused") context: GGMLContext, a: GGMLTensor, b: GGMLTensor): GGMLTensor {
-    // Check that the tensors have compatible dimensions for matrix multiplication
-    // a: m x n, b: n x p, result: m x p
-    val m = a.ne[0]
-    val n = a.ne[1]
-    val p = b.ne[1]
-
-    if (b.ne[0] != n) {
-        throw IllegalArgumentException("Incompatible dimensions for matrix multiplication")
-    }
-
-    // Create a new tensor for the result
-    val result = GGMLTensor(type = a.type)
-    result.ne[0] = m
-    result.ne[1] = p
-    for (i in 2 until GGML_MAX_DIMS) {
-        result.ne[i] = 1
-    }
-
-    // Set strides based on the data type
-    val typeSize = when (a.type) {
-        GGMLType.F32 -> 4u
-        GGMLType.F16 -> 2u
-        GGMLType.I8 -> 1u
-        GGMLType.I16 -> 2u
-        GGMLType.I32 -> 4u
-        GGMLType.I64 -> 8u
-        else -> 1u // Default for quantized types
-    }
-
-    result.nb[0] = typeSize.toULong()
-    result.nb[1] = result.nb[0] * result.ne[0].toULong()
-    for (i in 2 until GGML_MAX_DIMS) {
-        result.nb[i] = result.nb[i-1] * result.ne[i-1].toULong()
-    }
-
-    // Calculate total size
-    val totalSize = (m * p).toInt()
-
-    // Perform the matrix multiplication based on the tensor type
-    when (a.type) {
-        GGMLType.F32 -> {
-            val aData = a.data as FloatArray
-            val bData = b.data as FloatArray
-            val resultData = FloatArray(totalSize)
-
-            // Use block-based matrix multiplication for better cache utilization
-            val blockSize = 32 // Adjust based on cache size
-
-            // Initialize result to zeros
-            for (i in 0 until totalSize) {
-                resultData[i] = 0.0f
-            }
-
-            // Block-based matrix multiplication
-            for (ii in 0 until m.toInt() step blockSize) {
-                val iEnd = minOf(ii + blockSize, m.toInt())
-
-                for (kk in 0 until n.toInt() step blockSize) {
-                    val kEnd = minOf(kk + blockSize, n.toInt())
-
-                    for (jj in 0 until p.toInt() step blockSize) {
-                        val jEnd = minOf(jj + blockSize, p.toInt())
-
-                        // Process the current block
-                        for (i in ii until iEnd) {
-                            for (k in kk until kEnd) {
-                                val aVal = aData[i * n.toInt() + k]
-
-                                for (j in jj until jEnd) {
-                                    resultData[i * p.toInt() + j] += aVal * bData[k * p.toInt() + j]
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            result.data = resultData
-        }
-        GGMLType.F16 -> {
-            val aData = a.data as ShortArray
-            val bData = b.data as ShortArray
-            val resultData = ShortArray(totalSize)
-
-            // Use block-based matrix multiplication for better cache utilization
-            val blockSize = 32 // Adjust based on cache size
-
-            // Initialize result to zeros
-            for (i in 0 until totalSize) {
-                resultData[i] = 0
-            }
-
-            // Block-based matrix multiplication
-            for (ii in 0 until m.toInt() step blockSize) {
-                val iEnd = minOf(ii + blockSize, m.toInt())
-
-                for (kk in 0 until n.toInt() step blockSize) {
-                    val kEnd = minOf(kk + blockSize, n.toInt())
-
-                    for (jj in 0 until p.toInt() step blockSize) {
-                        val jEnd = minOf(jj + blockSize, p.toInt())
-
-                        // Process the current block
-                        for (i in ii until iEnd) {
-                            for (k in kk until kEnd) {
-                                // Convert short to float
-                                val aFloat = aData[i * n.toInt() + k].toFloat() / 32768.0f
-
-                                for (j in jj until jEnd) {
-                                    // Convert short to float, multiply, accumulate
-                                    val bFloat = bData[k * p.toInt() + j].toFloat() / 32768.0f
-                                    val currentVal = resultData[i * p.toInt() + j].toFloat() / 32768.0f
-                                    val newVal = currentVal + aFloat * bFloat
-
-                                    // Convert back to short
-                                    resultData[i * p.toInt() + j] = (newVal * 32768.0f).toInt().toShort()
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            result.data = resultData
         }
         GGMLType.I16 -> {
-            val aData = a.data as ShortArray
-            val bData = b.data as ShortArray
-            val resultData = ShortArray(totalSize)
-
-            // Use block-based matrix multiplication for better cache utilization
-            val blockSize = 32 // Adjust based on cache size
-
-            // Initialize result to zeros
-            for (i in 0 until totalSize) {
-                resultData[i] = 0
+            val resultData = ShortArray(ts); res.data = resultData
+            applyNDIter(a, ts) { flatIdx, indices ->
+                val valA = a.getShort(graphAllocator, *indices).toInt()
+                val valB = b.getShort(graphAllocator, *indices).toInt()
+                resultData[flatIdx] = (valA - valB).coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
             }
-
-            // Block-based matrix multiplication
-            for (ii in 0 until m.toInt() step blockSize) {
-                val iEnd = minOf(ii + blockSize, m.toInt())
-
-                for (kk in 0 until n.toInt() step blockSize) {
-                    val kEnd = minOf(kk + blockSize, n.toInt())
-
-                    for (jj in 0 until p.toInt() step blockSize) {
-                        val jEnd = minOf(jj + blockSize, p.toInt())
-
-                        // Process the current block
-                        for (i in ii until iEnd) {
-                            for (k in kk until kEnd) {
-                                val aVal = aData[i * n.toInt() + k]
-
-                                for (j in jj until jEnd) {
-                                    // Need to be careful with overflow
-                                    val product = aVal * bData[k * p.toInt() + j]
-                                    val sum = resultData[i * p.toInt() + j] + product
-                                    resultData[i * p.toInt() + j] = sum.toShort()
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            result.data = resultData
-        }
-        GGMLType.I32 -> {
-            val aData = a.data as IntArray
-            val bData = b.data as IntArray
-            val resultData = IntArray(totalSize)
-
-            // Use block-based matrix multiplication for better cache utilization
-            val blockSize = 32 // Adjust based on cache size
-
-            // Initialize result to zeros
-            for (i in 0 until totalSize) {
-                resultData[i] = 0
-            }
-
-            // Block-based matrix multiplication
-            for (ii in 0 until m.toInt() step blockSize) {
-                val iEnd = minOf(ii + blockSize, m.toInt())
-
-                for (kk in 0 until n.toInt() step blockSize) {
-                    val kEnd = minOf(kk + blockSize, n.toInt())
-
-                    for (jj in 0 until p.toInt() step blockSize) {
-                        val jEnd = minOf(jj + blockSize, p.toInt())
-
-                        // Process the current block
-                        for (i in ii until iEnd) {
-                            for (k in kk until kEnd) {
-                                val aVal = aData[i * n.toInt() + k]
-
-                                for (j in jj until jEnd) {
-                                    resultData[i * p.toInt() + j] += aVal * bData[k * p.toInt() + j]
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            result.data = resultData
         }
         GGMLType.I8 -> {
-            val aData = a.data as ByteArray
-            val bData = b.data as ByteArray
-            val resultData = ByteArray(totalSize)
-
-            // Use block-based matrix multiplication for better cache utilization
-            val blockSize = 32 // Adjust based on cache size
-
-            // Initialize result to zeros
-            for (i in 0 until totalSize) {
-                resultData[i] = 0
+            val resultData = ByteArray(ts); res.data = resultData
+            applyNDIter(a, ts) { flatIdx, indices ->
+                val valA = a.getByte(graphAllocator, *indices).toInt()
+                val valB = b.getByte(graphAllocator, *indices).toInt()
+                resultData[flatIdx] = (valA - valB).coerceIn(Byte.MIN_VALUE.toInt(), Byte.MAX_VALUE.toInt()).toByte()
             }
-
-            // Block-based matrix multiplication
-            for (ii in 0 until m.toInt() step blockSize) {
-                val iEnd = minOf(ii + blockSize, m.toInt())
-
-                for (kk in 0 until n.toInt() step blockSize) {
-                    val kEnd = minOf(kk + blockSize, n.toInt())
-
-                    for (jj in 0 until p.toInt() step blockSize) {
-                        val jEnd = minOf(jj + blockSize, p.toInt())
-
-                        // Process the current block
-                        for (i in ii until iEnd) {
-                            for (k in kk until kEnd) {
-                                val aVal = aData[i * n.toInt() + k]
-
-                                for (j in jj until jEnd) {
-                                    // Need to be careful with overflow
-                                    val product = aVal * bData[k * p.toInt() + j]
-                                    val sum = resultData[i * p.toInt() + j] + product
-                                    resultData[i * p.toInt() + j] = sum.toByte()
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            result.data = resultData
         }
         GGMLType.I64 -> {
-            val aData = a.data as LongArray
-            val bData = b.data as LongArray
-            val resultData = LongArray(totalSize)
-
-            // Use block-based matrix multiplication for better cache utilization
-            val blockSize = 32 // Adjust based on cache size
-
-            // Initialize result to zeros
-            for (i in 0 until totalSize) {
-                resultData[i] = 0L
+            val resultData = LongArray(ts); res.data = resultData
+            applyNDIter(a, ts) { flatIdx, indices ->
+                resultData[flatIdx] = a.getLong(graphAllocator, *indices) - b.getLong(graphAllocator, *indices)
             }
-
-            // Block-based matrix multiplication
-            for (ii in 0 until m.toInt() step blockSize) {
-                val iEnd = minOf(ii + blockSize, m.toInt())
-
-                for (kk in 0 until n.toInt() step blockSize) {
-                    val kEnd = minOf(kk + blockSize, n.toInt())
-
-                    for (jj in 0 until p.toInt() step blockSize) {
-                        val jEnd = minOf(jj + blockSize, p.toInt())
-
-                        // Process the current block
-                        for (i in ii until iEnd) {
-                            for (k in kk until kEnd) {
-                                val aVal = aData[i * n.toInt() + k]
-
-                                for (j in jj until jEnd) {
-                                    resultData[i * p.toInt() + j] += aVal * bData[k * p.toInt() + j]
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            result.data = resultData
         }
-        GGMLType.Q4_0, GGMLType.Q4_1, GGMLType.Q5_0, GGMLType.Q5_1, GGMLType.Q8_0, GGMLType.Q8_1 -> {
-            // Basic implementation for quantized types - dequantize, perform matrix multiplication, then requantize
-            // This is a placeholder and should be optimized in the future
-
-            // For now, we'll convert to F32, perform the operation, and convert back
-            // In a real implementation, we would have specialized code for each quantized type
-
-            // Create temporary F32 tensors
-            val aF32 = dequantizeTensor(a)
-            val bF32 = dequantizeTensor(b)
-
-            // Perform matrix multiplication in F32
-            val resultF32 = computeMatMul(context, aF32, bF32)
-
-            // Requantize to the original type
-            result.data = quantizeTensor(resultF32, a.type).data
-        }
-        else -> {
-            // For other types, we'll implement later
-            result.data = null
-        }
+        GGMLType.Q4_0,GGMLType.Q4_1,GGMLType.Q5_0,GGMLType.Q5_1,GGMLType.Q8_0,GGMLType.Q8_1->{val af=dequantizeTensor(graphAllocator,a); val bf=dequantizeTensor(graphAllocator,b); val rf=computeSub(graphAllocator,context,af,bf); val qr=quantizeTensor(graphAllocator,rf,a.type); res.data=qr.data}
+        else->throw NotImplementedError("computeSub NI for type ${a.type}")
     }
-
-    return result
+    return res
 }
 
-/**
- * Applies the ReLU activation function to a tensor.
- *
- * @param context The GGML context
- * @param a The input tensor
- * @return The result tensor
- */
-fun computeRelu(@Suppress("unused") context: GGMLContext, a: GGMLTensor): GGMLTensor {
-    // Create a new tensor for the result with the same dimensions as a
-    val result = GGMLTensor(type = a.type)
-    for (i in 0 until GGML_MAX_DIMS) {
-        result.ne[i] = a.ne[i]
-        result.nb[i] = a.nb[i]
+fun computeNeg(graphAllocator: GGMLGraphAllocator, @Suppress("unused") context: GGMLContext, a: GGMLTensor): GGMLTensor {
+    val res=GGMLTensor(a.type); res.ne=a.ne.copyOf(); res.nb=a.nb.copyOf(); val ts=res.numElements().toInt()
+    when(a.type){
+        GGMLType.F32->applyNDIter(res,ts){_,ind->res.setFloat(graphAllocator,-a.getFloat(graphAllocator,*ind),*ind)}
+        GGMLType.F16->applyNDIter(res,ts){_,ind->res.setHalf(graphAllocator,-a.getHalf(graphAllocator,*ind),*ind)}
+        GGMLType.Q4_0,GGMLType.Q4_1,GGMLType.Q5_0,GGMLType.Q5_1,GGMLType.Q8_0,GGMLType.Q8_1->{val af=dequantizeTensor(graphAllocator,a); val rf=computeNeg(graphAllocator,context,af); val qr=quantizeTensor(graphAllocator,rf,a.type); res.data=qr.data}
+        else->throw NotImplementedError("computeNeg NI for ${a.type}")
     }
+    return res
+}
 
-    // Calculate total size
-    val totalSize = calculateTotalSize(a.ne)
-
-    // Apply the ReLU function based on the tensor type
-    when (a.type) {
-        GGMLType.F32 -> {
-            val aData = a.data as FloatArray
-            val resultData = FloatArray(totalSize)
-
-            for (i in 0 until totalSize) {
-                resultData[i] = if (aData[i] > 0.0f) aData[i] else 0.0f
-            }
-
-            result.data = resultData
+fun computeDiv(graphAllocator: GGMLGraphAllocator, @Suppress("unused") context: GGMLContext, a: GGMLTensor, b: GGMLTensor): GGMLTensor {
+    for(i in 0 until GGML_MAX_DIMS){if(a.ne[i]!=b.ne[i])throw IllegalArgumentException("Dims mismatch")}
+    val res=GGMLTensor(a.type);res.ne=a.ne.copyOf();res.nb=a.nb.copyOf();val ts=res.numElements().toInt()
+    val div={vA:Float,vB:Float->if(vB==0.0f){if(vA==0.0f)Float.NaN else if(vA>0.0f)Float.POSITIVE_INFINITY else Float.NEGATIVE_INFINITY}else{vA/vB}}
+    when(a.type){
+        GGMLType.F32-> {
+            val resultData = FloatArray(ts); res.data = resultData
+            applyNDIter(a,ts){flatIdx,ind->resultData[flatIdx] = div(a.getFloat(graphAllocator,*ind),b.getFloat(graphAllocator,*ind))}
         }
-        GGMLType.F16 -> {
-            val aData = a.data as ShortArray
-            val resultData = ShortArray(totalSize)
-
-            for (i in 0 until totalSize) {
-                // Convert short to float, apply ReLU, convert back to short
-                val aFloat = aData[i].toFloat() / 32768.0f
-                val reluResult = if (aFloat > 0.0f) aFloat else 0.0f
-                resultData[i] = (reluResult * 32768.0f).toInt().toShort()
-            }
-
-            result.data = resultData
+        GGMLType.F16-> {
+            val resultData = ShortArray(ts); res.data = resultData
+            applyNDIter(a,ts){flatIdx,ind->resultData[flatIdx] = floatToHalf(div(a.getHalf(graphAllocator,*ind),b.getHalf(graphAllocator,*ind)))}
         }
-        GGMLType.I8 -> {
-            val aData = a.data as ByteArray
-            val resultData = ByteArray(totalSize)
-
-            for (i in 0 until totalSize) {
-                resultData[i] = if (aData[i] > 0) aData[i] else 0
+        GGMLType.I32 -> {
+            val resultData = IntArray(ts); res.data = resultData
+            applyNDIter(a, ts) { flatIdx, indices ->
+                val valA = a.getInt(graphAllocator, *indices)
+                val valB = b.getInt(graphAllocator, *indices)
+                if (valB == 0) throw ArithmeticException("Division by zero for I32")
+                resultData[flatIdx] = valA / valB
             }
-
-            result.data = resultData
         }
         GGMLType.I16 -> {
-            val aData = a.data as ShortArray
-            val resultData = ShortArray(totalSize)
-
-            for (i in 0 until totalSize) {
-                resultData[i] = if (aData[i] > 0) aData[i] else 0
+            val resultData = ShortArray(ts); res.data = resultData
+            applyNDIter(a, ts) { flatIdx, indices ->
+                val valA = a.getShort(graphAllocator, *indices).toInt()
+                val valB = b.getShort(graphAllocator, *indices).toInt()
+                if (valB == 0) throw ArithmeticException("Division by zero for I16")
+                resultData[flatIdx] = (valA / valB).coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
             }
-
-            result.data = resultData
-        }
-        GGMLType.I32 -> {
-            val aData = a.data as IntArray
-            val resultData = IntArray(totalSize)
-
-            for (i in 0 until totalSize) {
-                resultData[i] = if (aData[i] > 0) aData[i] else 0
-            }
-
-            result.data = resultData
-        }
-        GGMLType.I64 -> {
-            val aData = a.data as LongArray
-            val resultData = LongArray(totalSize)
-
-            for (i in 0 until totalSize) {
-                resultData[i] = if (aData[i] > 0) aData[i] else 0
-            }
-
-            result.data = resultData
-        }
-        else -> {
-            // For other types (quantized types), we'll implement later
-            result.data = null
-        }
-    }
-
-    return result
-}
-
-/**
- * Applies the GELU activation function to a tensor.
- *
- * @param context The GGML context
- * @param a The input tensor
- * @return The result tensor
- */
-fun computeGelu(@Suppress("unused") context: GGMLContext, a: GGMLTensor): GGMLTensor {
-    // Create a new tensor for the result with the same dimensions as a
-    val result = GGMLTensor(type = a.type)
-    for (i in 0 until GGML_MAX_DIMS) {
-        result.ne[i] = a.ne[i]
-        result.nb[i] = a.nb[i]
-    }
-
-    // Calculate total size
-    val totalSize = calculateTotalSize(a.ne)
-
-    // Apply the GELU function based on the tensor type
-    when (a.type) {
-        GGMLType.F32 -> {
-            val aData = a.data as FloatArray
-            val resultData = FloatArray(totalSize)
-
-            for (i in 0 until totalSize) {
-                // GELU approximation: x * 0.5 * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x^3)))
-                val x = aData[i]
-                resultData[i] = x * 0.5f * (1.0f + kotlin.math.tanh(0.797885f * (x + 0.044715f * x * x * x)))
-            }
-
-            result.data = resultData
-        }
-        GGMLType.F16 -> {
-            val aData = a.data as ShortArray
-            val resultData = ShortArray(totalSize)
-
-            for (i in 0 until totalSize) {
-                // Convert short to float, apply GELU, convert back to short
-                val x = aData[i].toFloat() / 32768.0f
-                val geluResult = x * 0.5f * (1.0f + kotlin.math.tanh(0.797885f * (x + 0.044715f * x * x * x)))
-                resultData[i] = (geluResult * 32768.0f).toInt().toShort()
-            }
-
-            result.data = resultData
-        }
-        GGMLType.I8, GGMLType.I16, GGMLType.I32, GGMLType.I64 -> {
-            // For integer types, convert to float, apply GELU, then convert back
-            // This is a simplified implementation that treats all integer types similarly
-
-            // Create a float array for intermediate calculations
-            val floatData = FloatArray(totalSize)
-
-            // Convert input data to float
-            when (a.type) {
-                GGMLType.I8 -> {
-                    val aData = a.data as ByteArray
-                    for (i in 0 until totalSize) {
-                        floatData[i] = aData[i].toFloat()
-                    }
-                }
-                GGMLType.I16 -> {
-                    val aData = a.data as ShortArray
-                    for (i in 0 until totalSize) {
-                        floatData[i] = aData[i].toFloat()
-                    }
-                }
-                GGMLType.I32 -> {
-                    val aData = a.data as IntArray
-                    for (i in 0 until totalSize) {
-                        floatData[i] = aData[i].toFloat()
-                    }
-                }
-                GGMLType.I64 -> {
-                    val aData = a.data as LongArray
-                    for (i in 0 until totalSize) {
-                        floatData[i] = aData[i].toFloat()
-                    }
-                }
-                else -> {} // Should not happen due to the when condition
-            }
-
-            // Apply GELU to float data
-            for (i in 0 until totalSize) {
-                val x = floatData[i]
-                floatData[i] = x * 0.5f * (1.0f + kotlin.math.tanh(0.797885f * (x + 0.044715f * x * x * x)))
-            }
-
-            // Convert back to the original type
-            when (a.type) {
-                GGMLType.I8 -> {
-                    val resultData = ByteArray(totalSize)
-                    for (i in 0 until totalSize) {
-                        resultData[i] = floatData[i].toInt().toByte()
-                    }
-                    result.data = resultData
-                }
-                GGMLType.I16 -> {
-                    val resultData = ShortArray(totalSize)
-                    for (i in 0 until totalSize) {
-                        resultData[i] = floatData[i].toInt().toShort()
-                    }
-                    result.data = resultData
-                }
-                GGMLType.I32 -> {
-                    val resultData = IntArray(totalSize)
-                    for (i in 0 until totalSize) {
-                        resultData[i] = floatData[i].toInt()
-                    }
-                    result.data = resultData
-                }
-                GGMLType.I64 -> {
-                    val resultData = LongArray(totalSize)
-                    for (i in 0 until totalSize) {
-                        resultData[i] = floatData[i].toLong()
-                    }
-                    result.data = resultData
-                }
-                else -> {} // Should not happen due to the when condition
-            }
-        }
-        else -> {
-            // For other types (quantized types), we'll implement later
-            result.data = null
-        }
-    }
-
-    return result
-}
-
-/**
- * Subtracts one tensor from another element-wise.
- *
- * @param context The GGML context
- * @param a The first tensor
- * @param b The second tensor
- * @return The result tensor (a - b)
- */
-fun computeSub(@Suppress("unused") context: GGMLContext, a: GGMLTensor, b: GGMLTensor): GGMLTensor {
-    // Check that the tensors have compatible dimensions
-    for (i in 0 until GGML_MAX_DIMS) {
-        if (a.ne[i] != b.ne[i]) {
-            throw IllegalArgumentException("Incompatible dimensions for subtraction")
-        }
-    }
-
-    // Create a new tensor for the result with the same dimensions as a
-    val result = GGMLTensor(type = a.type)
-    for (i in 0 until GGML_MAX_DIMS) {
-        result.ne[i] = a.ne[i]
-        result.nb[i] = a.nb[i]
-    }
-
-    // Calculate total size
-    val totalSize = calculateTotalSize(a.ne)
-
-    // Perform the subtraction based on the tensor type
-    when (a.type) {
-        GGMLType.F32 -> {
-            val aData = a.data as FloatArray
-            val bData = b.data as FloatArray
-            val resultData = FloatArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = aData[j] - bData[j]
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.F16 -> {
-            val aData = a.data as ShortArray
-            val bData = b.data as ShortArray
-            val resultData = ShortArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    // Convert shorts to floats, subtract, then convert back to short
-                    val aFloat = aData[j].toFloat() / 32768.0f
-                    val bFloat = bData[j].toFloat() / 32768.0f
-                    val diff = aFloat - bFloat
-                    resultData[j] = (diff * 32768.0f).toInt().toShort()
-                }
-                i = end
-            }
-
-            result.data = resultData
         }
         GGMLType.I8 -> {
-            val aData = a.data as ByteArray
-            val bData = b.data as ByteArray
-            val resultData = ByteArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = (aData[j] - bData[j]).toByte()
-                }
-                i = end
+            val resultData = ByteArray(ts); res.data = resultData
+            applyNDIter(a, ts) { flatIdx, indices ->
+                val valA = a.getByte(graphAllocator, *indices).toInt()
+                val valB = b.getByte(graphAllocator, *indices).toInt()
+                if (valB == 0) throw ArithmeticException("Division by zero for I8")
+                resultData[flatIdx] = (valA / valB).coerceIn(Byte.MIN_VALUE.toInt(), Byte.MAX_VALUE.toInt()).toByte()
             }
-
-            result.data = resultData
-        }
-        GGMLType.I16 -> {
-            val aData = a.data as ShortArray
-            val bData = b.data as ShortArray
-            val resultData = ShortArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = (aData[j] - bData[j]).toShort()
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.I32 -> {
-            val aData = a.data as IntArray
-            val bData = b.data as IntArray
-            val resultData = IntArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = aData[j] - bData[j]
-                }
-                i = end
-            }
-
-            result.data = resultData
         }
         GGMLType.I64 -> {
-            val aData = a.data as LongArray
-            val bData = b.data as LongArray
-            val resultData = LongArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = aData[j] - bData[j]
-                }
-                i = end
+            val resultData = LongArray(ts); res.data = resultData
+            applyNDIter(a, ts) { flatIdx, indices ->
+                val valA = a.getLong(graphAllocator, *indices)
+                val valB = b.getLong(graphAllocator, *indices)
+                if (valB == 0L) throw ArithmeticException("Division by zero for I64")
+                resultData[flatIdx] = valA / valB
             }
-
-            result.data = resultData
         }
-        GGMLType.Q4_0, GGMLType.Q4_1, GGMLType.Q5_0, GGMLType.Q5_1, GGMLType.Q8_0, GGMLType.Q8_1 -> {
-            // Basic implementation for quantized types - dequantize, subtract, then requantize
-            // This is a placeholder and should be optimized in the future
-
-            // For now, we'll convert to F32, perform the operation, and convert back
-            // In a real implementation, we would have specialized code for each quantized type
-
-            // Create temporary F32 tensors
-            val aF32 = dequantizeTensor(a)
-            val bF32 = dequantizeTensor(b)
-
-            // Perform subtraction in F32
-            val resultF32 = computeSub(context, aF32, bF32)
-
-            // Requantize to the original type
-            result.data = quantizeTensor(resultF32, a.type).data
-        }
-        else -> {
-            // For other types, we'll implement later
-            result.data = null
-        }
+        GGMLType.Q4_0,GGMLType.Q4_1,GGMLType.Q5_0,GGMLType.Q5_1,GGMLType.Q8_0,GGMLType.Q8_1->{val af=dequantizeTensor(graphAllocator,a);val bf=dequantizeTensor(graphAllocator,b);val rf=computeDiv(graphAllocator,context,af,bf);val qr=quantizeTensor(graphAllocator,rf,a.type);res.data=qr.data}
+        else->throw NotImplementedError("computeDiv NI for type ${a.type}")
     }
-
-    return result
+    return res
 }
 
-/**
- * Negates a tensor element-wise.
- *
- * @param context The GGML context
- * @param a The input tensor
- * @return The result tensor (-a)
- */
-fun computeNeg(@Suppress("unused") context: GGMLContext, a: GGMLTensor): GGMLTensor {
-    // Create a new tensor for the result with the same dimensions as a
-    val result = GGMLTensor(type = a.type)
-    for (i in 0 until GGML_MAX_DIMS) {
-        result.ne[i] = a.ne[i]
-        result.nb[i] = a.nb[i]
-    }
+[end of src/nativeMain/kotlin/ai/solace/llamakotlin/core/GGMLComputeOps.kt]
 
-    // Calculate total size
-    val totalSize = calculateTotalSize(a.ne)
-
-    // Perform the negation based on the tensor type
-    when (a.type) {
-        GGMLType.F32 -> {
-            val aData = a.data as FloatArray
-            val resultData = FloatArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = -aData[j]
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.F16 -> {
-            val aData = a.data as ShortArray
-            val resultData = ShortArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    // Convert short to float, negate, then convert back to short
-                    val aFloat = aData[j].toFloat() / 32768.0f
-                    val negated = -aFloat
-                    resultData[j] = (negated * 32768.0f).toInt().toShort()
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.I8 -> {
-            val aData = a.data as ByteArray
-            val resultData = ByteArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = (-aData[j]).toByte()
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.I16 -> {
-            val aData = a.data as ShortArray
-            val resultData = ShortArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = (-aData[j]).toShort()
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.I32 -> {
-            val aData = a.data as IntArray
-            val resultData = IntArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = -aData[j]
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.I64 -> {
-            val aData = a.data as LongArray
-            val resultData = LongArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    resultData[j] = -aData[j]
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.Q4_0, GGMLType.Q4_1, GGMLType.Q5_0, GGMLType.Q5_1, GGMLType.Q8_0, GGMLType.Q8_1 -> {
-            // Basic implementation for quantized types - dequantize, negate, then requantize
-            // This is a placeholder and should be optimized in the future
-
-            // For now, we'll convert to F32, perform the operation, and convert back
-            // In a real implementation, we would have specialized code for each quantized type
-
-            // Create temporary F32 tensor
-            val aF32 = dequantizeTensor(a)
-
-            // Perform negation in F32
-            val resultF32 = computeNeg(context, aF32)
-
-            // Requantize to the original type
-            result.data = quantizeTensor(resultF32, a.type).data
-        }
-        else -> {
-            // For other types, we'll implement later
-            result.data = null
-        }
-    }
-
-    return result
-}
-
-/**
- * Divides one tensor by another element-wise.
- *
- * @param context The GGML context
- * @param a The numerator tensor
- * @param b The denominator tensor
- * @return The result tensor (a / b)
- */
-fun computeDiv(@Suppress("unused") context: GGMLContext, a: GGMLTensor, b: GGMLTensor): GGMLTensor {
-    // Check that the tensors have compatible dimensions
-    for (i in 0 until GGML_MAX_DIMS) {
-        if (a.ne[i] != b.ne[i]) {
-            throw IllegalArgumentException("Incompatible dimensions for division")
-        }
-    }
-
-    // Create a new tensor for the result with the same dimensions as a
-    val result = GGMLTensor(type = a.type)
-    for (i in 0 until GGML_MAX_DIMS) {
-        result.ne[i] = a.ne[i]
-        result.nb[i] = a.nb[i]
-    }
-
-    // Calculate total size
-    val totalSize = calculateTotalSize(a.ne)
-
-    // Perform division based on the tensor type
-    when (a.type) {
-        GGMLType.F32 -> {
-            val aData = a.data as FloatArray
-            val bData = b.data as FloatArray
-            val resultData = FloatArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    if (bData[j] == 0.0f) {
-                        // Handle division by zero
-                        resultData[j] = if (aData[j] == 0.0f) {
-                            Float.NaN // 0/0 = NaN
-                        } else if (aData[j] > 0.0f) {
-                            Float.POSITIVE_INFINITY // positive/0 = +Infinity
-                        } else {
-                            Float.NEGATIVE_INFINITY // negative/0 = -Infinity
-                        }
-                    } else {
-                        resultData[j] = aData[j] / bData[j]
-                    }
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.F16 -> {
-            val aData = a.data as ShortArray
-            val bData = b.data as ShortArray
-            val resultData = ShortArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    // Convert shorts to floats
-                    val aFloat = aData[j].toFloat() / 32768.0f
-                    val bFloat = bData[j].toFloat() / 32768.0f
-
-                    // Perform division
-                    val resultFloat = if (bFloat == 0.0f) {
-                        if (aFloat == 0.0f) {
-                            Float.NaN // 0/0 = NaN
-                        } else if (aFloat > 0.0f) {
-                            Float.POSITIVE_INFINITY // positive/0 = +Infinity
-                        } else {
-                            Float.NEGATIVE_INFINITY // negative/0 = -Infinity
-                        }
-                    } else {
-                        aFloat / bFloat
-                    }
-
-                    // Convert back to short
-                    resultData[j] = (resultFloat * 32768.0f).toInt().toShort()
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.I8 -> {
-            val aData = a.data as ByteArray
-            val bData = b.data as ByteArray
-            val resultData = ByteArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    if (bData[j] == 0.toByte()) {
-                        // Handle division by zero - for integer types, we'll use 0 as a default
-                        resultData[j] = 0
-                    } else {
-                        resultData[j] = (aData[j] / bData[j]).toByte()
-                    }
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.I16 -> {
-            val aData = a.data as ShortArray
-            val bData = b.data as ShortArray
-            val resultData = ShortArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    if (bData[j] == 0.toShort()) {
-                        // Handle division by zero - for integer types, we'll use 0 as a default
-                        resultData[j] = 0
-                    } else {
-                        resultData[j] = (aData[j] / bData[j]).toShort()
-                    }
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.I32 -> {
-            val aData = a.data as IntArray
-            val bData = b.data as IntArray
-            val resultData = IntArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    if (bData[j] == 0) {
-                        // Handle division by zero - for integer types, we'll use 0 as a default
-                        resultData[j] = 0
-                    } else {
-                        resultData[j] = aData[j] / bData[j]
-                    }
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.I64 -> {
-            val aData = a.data as LongArray
-            val bData = b.data as LongArray
-            val resultData = LongArray(totalSize)
-
-            // Process in chunks for better cache utilization
-            val chunkSize = 128
-            var i = 0
-            while (i < totalSize) {
-                val end = minOf(i + chunkSize, totalSize)
-                for (j in i until end) {
-                    if (bData[j] == 0L) {
-                        // Handle division by zero - for integer types, we'll use 0 as a default
-                        resultData[j] = 0L
-                    } else {
-                        resultData[j] = aData[j] / bData[j]
-                    }
-                }
-                i = end
-            }
-
-            result.data = resultData
-        }
-        GGMLType.Q4_0, GGMLType.Q4_1, GGMLType.Q5_0, GGMLType.Q5_1, GGMLType.Q8_0, GGMLType.Q8_1 -> {
-            // Basic implementation for quantized types - dequantize, divide, then requantize
-            // This is a placeholder and should be optimized in the future
-
-            // For now, we'll convert to F32, perform the operation, and convert back
-            // In a real implementation, we would have specialized code for each quantized type
-
-            // Create temporary F32 tensors
-            val aF32 = dequantizeTensor(a)
-            val bF32 = dequantizeTensor(b)
-
-            // Perform division in F32
-            val resultF32 = computeDiv(context, aF32, bF32)
-
-            // Requantize to the original type
-            result.data = quantizeTensor(resultF32, a.type).data
-        }
-        else -> {
-            // For other types, we'll implement later
-            result.data = null
-        }
-    }
-
-    return result
-}
+[end of src/nativeMain/kotlin/ai/solace/llamakotlin/core/GGMLComputeOps.kt]

--- a/src/nativeMain/kotlin/ai/solace/llamakotlin/core/GGMLTypes.kt
+++ b/src/nativeMain/kotlin/ai/solace/llamakotlin/core/GGMLTypes.kt
@@ -1,6 +1,61 @@
 package ai.solace.llamakotlin.core
 
 import kotlin.native.concurrent.SharedImmutable
+import kotlin.Short.Companion.SIZE_BYTES
+
+// Numeric conversion functions (assuming they are in the same package or imported)
+// import ai.solace.llamakotlin.core.halfToFloat // Not needed if in same file/package
+// import ai.solace.llamakotlin.core.floatToHalf // Not needed if in same file/package
+
+// Helper functions for Little Endian byte conversions
+internal fun ByteArray.getIntLe(offset: Int): Int {
+    if (offset + 3 >= size) throw IndexOutOfBoundsException("Not enough bytes to read an Int at offset $offset")
+    return (this[offset].toInt() and 0xFF) or
+            ((this[offset + 1].toInt() and 0xFF) shl 8) or
+            ((this[offset + 2].toInt() and 0xFF) shl 16) or
+            ((this[offset + 3].toInt() and 0xFF) shl 24)
+}
+
+internal fun ByteArray.getFloatLe(offset: Int): Float = Float.fromBits(this.getIntLe(offset))
+
+internal fun ByteArray.setIntLe(offset: Int, value: Int) {
+    if (offset + 3 >= size) throw IndexOutOfBoundsException("Not enough bytes to write an Int at offset $offset")
+    this[offset] = (value and 0xFF).toByte()
+    this[offset + 1] = ((value shr 8) and 0xFF).toByte()
+    this[offset + 2] = ((value shr 16) and 0xFF).toByte()
+    this[offset + 3] = ((value shr 24) and 0xFF).toByte()
+}
+
+internal fun ByteArray.setFloatLe(offset: Int, value: Float) = this.setIntLe(offset, value.toRawBits())
+
+internal fun ByteArray.getShortLe(offset: Int): Short {
+    if (offset + 1 >= size) throw IndexOutOfBoundsException("Not enough bytes to read a Short at offset $offset")
+    return ((this[offset].toInt() and 0xFF) or
+            ((this[offset + 1].toInt() and 0xFF) shl 8)).toShort()
+}
+
+internal fun ByteArray.setShortLe(offset: Int, value: Short) {
+    if (offset + 1 >= size) throw IndexOutOfBoundsException("Not enough bytes to write a Short at offset $offset")
+    this[offset] = (value.toInt() and 0xFF).toByte()
+    this[offset + 1] = ((value.toInt() shr 8) and 0xFF).toByte()
+}
+
+internal fun ByteArray.getLongLe(offset: Int): Long {
+    require(offset + Long.SIZE_BYTES <= size) { "Offset $offset + ${Long.SIZE_BYTES} > size $size" }
+    var result = 0L
+    for (i in 0 until Long.SIZE_BYTES) {
+        result = result or ((this[offset + i].toLong() and 0xFF) shl (i * 8))
+    }
+    return result
+}
+
+internal fun ByteArray.setLongLe(offset: Int, value: Long) {
+    require(offset + Long.SIZE_BYTES <= size) { "Offset $offset + ${Long.SIZE_BYTES} > size $size" }
+    for (i in 0 until Long.SIZE_BYTES) {
+        this[offset + i] = ((value shr (i * 8)) and 0xFF).toByte()
+    }
+}
+
 
 /**
  * Kotlin Native port of GGML tensor library core data types.
@@ -26,74 +81,87 @@ const val GGML_MAX_OP_PARAMS = 32
  * Maximum name length for a tensor
  */
 const val GGML_MAX_NAME = 64
+const val GGML_TENSOR_FLAG_OUTPUT = 1 shl 0
+internal const val QK8_0: Int = 32 // Block size for Q8_0 blocks
+internal const val QK4_0: Int = 32 // Block size for Q4_0 blocks
+internal const val QK4_1: Int = 32 // Block size for Q4_1 blocks (same number of elements as Q4_0)
 
 /**
  * Tensor data types
  */
-enum class GGMLType {
-    F32,    // 32-bit float
-    F16,    // 16-bit float
-    Q4_0,   // 4-bit quantized
-    Q4_1,   // 4-bit quantized with different scaling
-    Q5_0,   // 5-bit quantized
-    Q5_1,   // 5-bit quantized with different scaling
-    Q8_0,   // 8-bit quantized
-    Q8_1,   // 8-bit quantized with different scaling
-    Q2_K,   // 2-bit quantized for K-quants
-    Q3_K,   // 3-bit quantized for K-quants
-    Q4_K,   // 4-bit quantized for K-quants
-    Q5_K,   // 5-bit quantized for K-quants
-    Q6_K,   // 6-bit quantized for K-quants
-    Q8_K,   // 8-bit quantized for K-quants
-    Q1_5_K, // 1.5-bit quantized for K-quants (ternary: -1, 0, 1)
-    I8,     // 8-bit integer
-    I16,    // 16-bit integer
-    I32,    // 32-bit integer
-    I64,    // 64-bit integer
-    COUNT   // Number of types
+@Suppress("UNUSED_PARAMETER") // For description in enum, if not used elsewhere
+enum class GGMLType(val description: String, val byteSize: ULong) {
+    F32("float32", 4uL),    // 32-bit float
+    F16("float16", 2uL),    // 16-bit float
+    // For quantized types, byteSize here represents the size of the fundamental element IF applicable for simple stride calculations.
+    // Actual memory per element for quantized types is fractional and depends on block size.
+    // Using 0uL as a placeholder signifies that direct byteSize-based stride calculation isn't straightforward.
+    // The ggml library itself has type_size and block_size fields and functions like ggml_type_size() / ggml_blck_size().
+    // For now, these are placeholders. The stride logic will primarily rely on non-zero byteSize for unquantized types.
+    // Q4_0 byteSize is per block: sizeof(F16 scale) + (QK4_0/2) * sizeof(I8 weights_packed)
+    Q4_0("q4_0", 2uL + (QK4_0 / 2).toULong()),   // 4-bit quantized, 18 bytes per block (2 + 32/2*1)
+    // Q4_1 byteSize is per block: 2 * sizeof(F16 scale/min) + (QK4_1/2) * sizeof(I8 weights_packed)
+    Q4_1("q4_1", (2uL * SIZE_BYTES.toULong()) + (QK4_1 / 2).toULong()),   // 4-bit quantized: 2*F16 (scale d, min m) + QK4_1/2 bytes for packed weights = 4 + 16 = 20 bytes per block
+    Q5_0("q5_0", 0uL),   // 5-bit quantized
+    Q5_1("q5_1", 0uL),   // 5-bit quantized with different scaling
+    // Q8_0 byteSize is per block: sizeof(Float16 for scale) + QK8_0 * sizeof(Int8 for weights)
+    Q8_0("q8_0", 2uL + QK8_0.toULong()),   // 8-bit quantized, 34 bytes per block (2 + 32*1)
+    Q8_1("q8_1", 0uL),   // 8-bit quantized with different scaling
+    Q2_K("q2_k", 0uL),   // 2-bit quantized for K-quants
+    Q3_K("q3_k", 0uL),   // 3-bit quantized for K-quants
+    Q4_K("q4_k", 0uL),   // 4-bit quantized for K-quants
+    Q5_K("q5_k", 0uL),   // 5-bit quantized for K-quants
+    Q6_K("q6_k", 0uL),   // 6-bit quantized for K-quants
+    Q8_K("q8_k", 0uL),   // 8-bit quantized for K-quants (potentially 1 byte + K-scale factor)
+    Q1_5_K("q1_5_k", 0uL), // 1.5-bit quantized for K-quants (ternary: -1, 0, 1) - size is complex
+    I8("int8", 1uL),     // 8-bit integer
+    I16("int16", 2uL),    // 16-bit integer
+    I32("int32", 4uL),    // 32-bit integer
+    I64("int64", 8uL),    // 64-bit integer
+    COUNT("count", 0uL)   // Number of types (not a real data type)
 }
 
 /**
  * Tensor operations
  */
-enum class GGMLOp {
+enum class GGMLOp(val canBeInplace: Boolean = false) {
     NONE,
     DUP,
-    ADD,
-    SUB,
-    MUL,
-    DIV,
-    SQR,
-    SQRT,
-    SUM,
-    MEAN,
+    ADD(true),
+    SUB(true),
+    MUL(true), // Element-wise multiplication
+    DIV(true),
+    SQR(true),
+    SQRT(true),
+    SUM, // Typically not inplace (reduces dimensions)
+    MEAN, // Typically not inplace
     REPEAT,
-    ABS,
-    SGN,
-    NEG,
-    STEP,
-    RELU,
-    GELU,
-    SILU,
-    NORM,
-    RMS_NORM,
-    MUL_MAT,
-    SCALE,
-    CPY,
-    RESHAPE,
-    VIEW,
+    ABS(true),
+    SGN(true),
+    NEG(true),
+    STEP(true),
+    RELU(true),
+    GELU(true),
+    SILU(true),
+    NORM(true), // LayerNorm, can be inplace if shapes match and specific handling
+    RMS_NORM(true),
+    MUL_MAT, // Matrix multiplication, typically not inplace
+    SCALE(true),
+    CPY, // Copy, not inplace by definition of creating a new tensor with copied data
+    RESHAPE, // Reshape is a view, metadata change, not inplace on data buffer in the same way
+    VIEW,    // View is a metadata change
     PERMUTE,
     TRANSPOSE,
     GET_ROWS,
-    DIAG_MASK_INF,
-    SOFT_MAX,
-    ROPE,
+    DIAG_MASK_INF(true),
+    SOFT_MAX(true), // Can be made inplace
+    ROPE(true),
     CONV_1D_1S,
     CONV_1D_2S,
     FLASH_ATTN,
     FLASH_FF,
-    MAP_UNARY,
-    MAP_BINARY,
+    MAP_UNARY, // Depends on the specific unary op mapped
+    MAP_BINARY, // Depends on the specific binary op mapped
     COUNT
 }
 
@@ -136,8 +204,473 @@ class GGMLTensor(
     var viewSrc: GGMLTensor? = null,
     var viewOffs: ULong = 0u,
     var data: Any? = null,
-    var name: String = ""
-)
+    var name: String = "",
+    var bufferId: Int = -1,
+    var dataOffset: ULong = 0u
+) {
+    fun isOutput(): Boolean = (this.flags and GGML_TENSOR_FLAG_OUTPUT) != 0
+
+    /**
+     * Calculates the rank of the tensor (number of dimensions > 1).
+     * Or 0 for a scalar that might have ne=[1,1,1,1] or ne=[].
+     * Or 1 for a vector that might be ne=[N,1,1,1].
+     */
+    internal fun rank(): Int {
+        if (ne.all { it <= 1L }) { // Covers scalars like [1,1,1,1] and true 0-rank like [] if ne can be empty
+            return if (ne.any { it > 0L}) 1 else 0 // Treat ne=[1,1,1,1] as rank 1 for element calculation if needed
+        }
+        return ne.indexOfLast { it > 1L } + 1
+    }
+
+    /**
+     * Calculates the total number of elements in the tensor.
+     * For block-quantized types, this is the total number of fundamental elements (e.g., individual weights).
+     */
+    fun numElements(): Long {
+        if (ne.isEmpty()) return 0L
+        var count = 1L
+        // Only multiply dimensions that are part of the tensor's actual rank
+        // or all dimensions if it's a scalar represented by [1,1,1,1]
+        val r = rank()
+        if (r == 0 && ne.all { it <= 1L}) return 1L // Scalar, effectively 1 element
+        if (r == 0 && ne.any { it == 0L}) return 0L // Not a valid tensor shape for elements typically
+
+        for (i in 0 until r.coerceAtLeast(1)) { // Iterate at least once for scalars like ne=[N]
+             if (ne[i] == 0L && r > 1) return 0L // Invalid dimension in a multi-dim tensor
+             if (ne[i] > 0L) count *= ne[i]
+        }
+        return count
+    }
+
+    internal fun isValidZeroSizedTensor(): Boolean {
+        // COUNT type is a valid zero-sized tensor (conceptual, no data).
+        if (this.type == GGMLType.COUNT) {
+            return true
+        }
+        // If any dimension (ne[i]) for the actual rank of the tensor is 0,
+        // then the total number of elements is 0, making it a valid zero-sized tensor.
+        // rank() can be 0 for an uninitialized tensor (ne all 0s or 1s but effectively no elements).
+        // rank() can be 1 for ne=[N,1,1,1]. Loop from 0 until rank().
+        val r = this.rank()
+        if (r == 0 && this.ne.all { it <= 0L }) return true // An uninitialized or ne=[] tensor is zero-sized
+        if (r == 0 && this.ne.any { it > 0L }) return false // A scalar like ne=[1,1,1,1] is not zero-sized
+
+        for (i in 0 until r) { // Iterate up to actual rank
+            if (this.ne[i] == 0L) {
+                return true
+            }
+        }
+        // If type.byteSize is 0 for a non-COUNT type, but numElements > 0,
+        // it's an issue with type definition, not a valid zero-sized data tensor.
+        // That case is handled by warnings elsewhere (e.g. stride calculation).
+        // This function focuses on whether the *data itself* is zero-sized due to dimensions.
+        return false
+    }
+
+    // Helper to calculate byte offset of an element given its indices
+    private fun getElementByteOffset(vararg indices: Int): ULong {
+        // The nb array in ggml stores the strides directly:
+        // nb[0] = stride for dim 0 (e.g. type_size for contiguous)
+        // nb[1] = stride for dim 1 (e.g. ne[0]*type_size for contiguous)
+        // ...
+        // For a tensor t, address of t(i0,i1,i2,i3) = t->data + i0*t->nb[0] + i1*t->nb[1] + i2*t->nb[2] + i3*t->nb[3].
+        // This is the interpretation this function will use.
+
+        var finalOffset = 0uL
+        // Number of actual dimensions in the tensor (where ne[d] > 1)
+        // val rank = ne.count { it > 1L }
+        // if (indices.size != rank && !(rank == 0 && indices.isEmpty())) {
+        //    throw IllegalArgumentException("Number of indices (${indices.size}) must match tensor rank ($rank). Tensor shape: ${ne.joinToString()}. Indices: ${indices.joinToString()}")
+        // }
+        // The above rank check might be too strict if ne contains trailing 1s for lower rank tensors.
+        // Example: A 2D tensor might have ne = [10, 20, 1, 1]. Rank is 2. indices.size should be 2.
+
+        // Iterating up to indices.size assumes that the provided indices match the intended dimensions.
+        for (d in indices.indices) {
+            if (d >= GGML_MAX_DIMS) { // Should not happen if indices.size is checked against rank based on ne
+                throw IllegalArgumentException("Dimension index $d exceeds GGML_MAX_DIMS.")
+            }
+            if (indices[d] < 0 || indices[d] >= ne[d]) {
+                val shapeString = ne.joinToString(limit = GGML_MAX_DIMS)
+                throw IllegalArgumentException("Index ${indices[d]} for dimension $d is out of bounds (0 to ${ne[d] - 1}) for tensor shape [$shapeString]")
+            }
+            finalOffset += indices[d].toULong() * nb[d]
+        }
+        return finalOffset
+    }
+
+    // Accessor methods for F32
+    fun getFloat(graphAllocator: GGMLGraphAllocator, vararg indices: Int): Float {
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId. Ensure graphAllocator.buffers is populated.")
+        val elementByteOffset = getElementByteOffset(*indices)
+        val finalByteOffset = dataOffset + elementByteOffset
+        if (finalByteOffset + 4u > buffer.size.toUInt()) { // Check for F32 size
+            throw IndexOutOfBoundsException("Calculated offset $finalByteOffset + 4 bytes for F32 is out of bounds for buffer size ${buffer.size}")
+        }
+        return buffer.getFloatLe(finalByteOffset.toInt())
+    }
+
+    fun setFloat(graphAllocator: GGMLGraphAllocator, value: Float, vararg indices: Int) {
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId. Ensure graphAllocator.buffers is populated.")
+        val elementByteOffset = getElementByteOffset(*indices)
+        val finalByteOffset = dataOffset + elementByteOffset
+        if (finalByteOffset + 4u > buffer.size.toUInt()) { // Check for F32 size
+            throw IndexOutOfBoundsException("Calculated offset $finalByteOffset + 4 bytes for F32 is out of bounds for buffer size ${buffer.size}")
+        }
+        buffer.setFloatLe(finalByteOffset.toInt(), value)
+    }
+
+    // Accessor methods for I32
+    fun getInt(graphAllocator: GGMLGraphAllocator, vararg indices: Int): Int {
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId. Ensure graphAllocator.buffers is populated.")
+        val elementByteOffset = getElementByteOffset(*indices)
+        val finalByteOffset = dataOffset + elementByteOffset
+        if (finalByteOffset + 4u > buffer.size.toUInt()) { // Check for I32 size
+            throw IndexOutOfBoundsException("Calculated offset $finalByteOffset + 4 bytes for I32 is out of bounds for buffer size ${buffer.size}")
+        }
+        return buffer.getIntLe(finalByteOffset.toInt())
+    }
+
+    fun setInt(graphAllocator: GGMLGraphAllocator, value: Int, vararg indices: Int) {
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId. Ensure graphAllocator.buffers is populated.")
+        val elementByteOffset = getElementByteOffset(*indices)
+        val finalByteOffset = dataOffset + elementByteOffset
+        if (finalByteOffset + 4u > buffer.size.toUInt()) { // Check for I32 size
+            throw IndexOutOfBoundsException("Calculated offset $finalByteOffset + 4 bytes for I32 is out of bounds for buffer size ${buffer.size}")
+        }
+        buffer.setIntLe(finalByteOffset.toInt(), value)
+    }
+
+    // Accessor methods for I16
+    fun getShort(graphAllocator: GGMLGraphAllocator, vararg indices: Int): Short {
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId. Ensure graphAllocator.buffers is populated.")
+        val elementByteOffset = getElementByteOffset(*indices)
+        val finalByteOffset = dataOffset + elementByteOffset
+        if (finalByteOffset + 2u > buffer.size.toUInt()) { // Check for I16 size
+            throw IndexOutOfBoundsException("Calculated offset $finalByteOffset + 2 bytes for I16 is out of bounds for buffer size ${buffer.size}")
+        }
+        return buffer.getShortLe(finalByteOffset.toInt())
+    }
+
+    fun setShort(graphAllocator: GGMLGraphAllocator, value: Short, vararg indices: Int) {
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId. Ensure graphAllocator.buffers is populated.")
+        val elementByteOffset = getElementByteOffset(*indices)
+        val finalByteOffset = dataOffset + elementByteOffset
+        if (finalByteOffset + 2u > buffer.size.toUInt()) { // Check for I16 size
+            throw IndexOutOfBoundsException("Calculated offset $finalByteOffset + 2 bytes for I16 is out of bounds for buffer size ${buffer.size}")
+        }
+        buffer.setShortLe(finalByteOffset.toInt(), value)
+    }
+
+    // Accessor methods for F16 (Half Float)
+    fun getHalf(graphAllocator: GGMLGraphAllocator, vararg indices: Int): Float {
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId. Ensure graphAllocator.buffers is populated.")
+        val elementByteOffset = getElementByteOffset(*indices)
+        val finalByteOffset = dataOffset + elementByteOffset
+        // Check bounds, considering Short.SIZE_BYTES (2 bytes for F16)
+        if (finalByteOffset.toInt() < 0 || finalByteOffset.toInt() + SIZE_BYTES > buffer.size) {
+            throw IndexOutOfBoundsException("Attempt to read Short at offset ${finalByteOffset.toInt()} (tensor offset $dataOffset + element offset $elementByteOffset) is out of buffer bounds (0-${buffer.size - SIZE_BYTES})")
+        }
+        val shortBits = buffer.getShortLe(finalByteOffset.toInt())
+        return halfToFloat(shortBits) // halfToFloat is in NumericConversions.kt, assumed imported or accessible
+    }
+
+    fun setHalf(graphAllocator: GGMLGraphAllocator, value: Float, vararg indices: Int) {
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId. Ensure graphAllocator.buffers is populated.")
+        val elementByteOffset = getElementByteOffset(*indices)
+        val finalByteOffset = dataOffset + elementByteOffset
+        // Check bounds, considering Short.SIZE_BYTES (2 bytes for F16)
+        if (finalByteOffset.toInt() < 0 || finalByteOffset.toInt() + SIZE_BYTES > buffer.size) {
+            throw IndexOutOfBoundsException("Attempt to write Short at offset ${finalByteOffset.toInt()} (tensor offset $dataOffset + element offset $elementByteOffset) is out of buffer bounds (0-${buffer.size - SIZE_BYTES})")
+        }
+        val shortBits = floatToHalf(value) // floatToHalf is in NumericConversions.kt, assumed imported or accessible
+        buffer.setShortLe(finalByteOffset.toInt(), shortBits)
+    }
+
+    // Accessor methods for I8 (Byte)
+    fun getByte(graphAllocator: GGMLGraphAllocator, vararg indices: Int): Byte {
+        // require(type == GGMLType.I8) { "getByte() called on non-I8 tensor: $type" }
+        val buffer = graphAllocator.buffers[bufferId] ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId")
+        val elementByteOffset = getElementByteOffset(*indices)
+        val finalByteOffset = dataOffset + elementByteOffset
+        if (finalByteOffset.toInt() < 0 || finalByteOffset.toInt() + Byte.SIZE_BYTES > buffer.size) {
+            throw IndexOutOfBoundsException("Attempt to read Byte at offset ${finalByteOffset.toInt()} (tensor offset $dataOffset + element offset $elementByteOffset) is out of buffer bounds (0-${buffer.size - Byte.SIZE_BYTES}) for tensor $name")
+        }
+        return buffer[finalByteOffset.toInt()]
+    }
+
+    fun setByte(graphAllocator: GGMLGraphAllocator, value: Byte, vararg indices: Int) {
+        // require(type == GGMLType.I8) { "setByte() called on non-I8 tensor: $type" }
+        val buffer = graphAllocator.buffers[bufferId] ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId")
+        val elementByteOffset = getElementByteOffset(*indices)
+        val finalByteOffset = dataOffset + elementByteOffset
+        if (finalByteOffset.toInt() < 0 || finalByteOffset.toInt() + Byte.SIZE_BYTES > buffer.size) {
+            throw IndexOutOfBoundsException("Attempt to write Byte at offset ${finalByteOffset.toInt()} (tensor offset $dataOffset + element offset $elementByteOffset) is out of buffer bounds (0-${buffer.size - Byte.SIZE_BYTES}) for tensor $name")
+        }
+        buffer[finalByteOffset.toInt()] = value
+    }
+
+    // Accessor methods for I64 (Long)
+    fun getLong(graphAllocator: GGMLGraphAllocator, vararg indices: Int): Long {
+        // require(type == GGMLType.I64) { "getLong() called on non-I64 tensor: $type" }
+        val buffer = graphAllocator.buffers[bufferId] ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId")
+        val elementByteOffset = getElementByteOffset(*indices)
+        val finalByteOffset = dataOffset + elementByteOffset
+        if (finalByteOffset.toInt() < 0 || finalByteOffset.toInt() + Long.SIZE_BYTES > buffer.size) {
+            throw IndexOutOfBoundsException("Attempt to read Long at offset ${finalByteOffset.toInt()} (tensor offset $dataOffset + element offset $elementByteOffset) is out of buffer bounds (0-${buffer.size - Long.SIZE_BYTES}) for tensor $name")
+        }
+        return buffer.getLongLe(finalByteOffset.toInt()) // Uses new ByteArray extension
+    }
+
+    fun setLong(graphAllocator: GGMLGraphAllocator, value: Long, vararg indices: Int) {
+        // require(type == GGMLType.I64) { "setLong() called on non-I64 tensor: $type" }
+        val buffer = graphAllocator.buffers[bufferId] ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId")
+        val elementByteOffset = getElementByteOffset(*indices)
+        val finalByteOffset = dataOffset + elementByteOffset
+        if (finalByteOffset.toInt() < 0 || finalByteOffset.toInt() + Long.SIZE_BYTES > buffer.size) {
+            throw IndexOutOfBoundsException("Attempt to write Long at offset ${finalByteOffset.toInt()} (tensor offset $dataOffset + element offset $elementByteOffset) is out of buffer bounds (0-${buffer.size - Long.SIZE_BYTES}) for tensor $name")
+        }
+        buffer.setLongLe(finalByteOffset.toInt(), value) // Uses new ByteArray extension
+    }
+
+    // --- Q8_0 Accessors ---
+
+    /**
+     * For Q8_0 and similar block-quantized types, calculates the number of blocks.
+     * Assumes ne holds the number of fundamental elements (e.g., individual weights).
+     */
+    fun getNumBlocks(): Long {
+        val totalElements = numElements()
+        if (totalElements == 0L) return 0L
+
+        val elementsPerBlock = when (type) {
+            GGMLType.Q8_0 -> QK8_0.toLong()
+            GGMLType.Q4_0 -> QK4_0.toLong()
+            GGMLType.Q4_1 -> QK4_1.toLong()
+            // Future block types can be added here
+            else -> {
+                // Or throw IllegalArgumentException("getNumBlocks is only for block-quantized types")
+                return 0L
+            }
+        }
+        if (elementsPerBlock == 0L) return 0L // Avoid division by zero
+
+        // Ensure that total elements are a multiple of block size, as per ggml constraints.
+        // If not, it indicates an issue with tensor setup or understanding of its true dimensions.
+        if (totalElements % elementsPerBlock != 0L) {
+            // This is usually an error in ggml, as tensors are expected to be whole blocks.
+            // However, some implementations might pad. For strictness, one might throw here.
+            // For now, simple integer division, implying full blocks.
+            println("Warning: Tensor ${name} of type ${type} has total elements $totalElements which is not perfectly divisible by block size $elementsPerBlock.")
+        }
+        return totalElements / elementsPerBlock
+    }
+
+    /**
+     * Retrieves the F16 scale for a specific block in a Q8_0 quantized tensor.
+     * @param graphAllocator The graph allocator holding the buffer.
+     * @param blockIndex The 0-based index of the block.
+     * @return The scale value as a Float.
+     */
+    fun getQ8_0BlockScale(graphAllocator: GGMLGraphAllocator, blockIndex: Int): Float {
+        require(type == GGMLType.Q8_0) { "Tensor type must be Q8_0 to get block scale." }
+        val numBlocks = getNumBlocks()
+        require(blockIndex >= 0 && blockIndex < numBlocks) { "blockIndex $blockIndex out of bounds for $numBlocks blocks in tensor '$name'." }
+
+        // type.byteSize for Q8_0 is the size of one block (e.g., 34 bytes)
+        val blockByteOffset = blockIndex.toULong() * type.byteSize
+        val finalScaleByteOffset = dataOffset + blockByteOffset
+
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId. Ensure graphAllocator.buffers is populated for tensor '$name'.")
+
+        // The scale is the first F16 (2 bytes) in the block
+        if (finalScaleByteOffset.toInt() < 0 || finalScaleByteOffset.toInt() + SHORT_SIZE_BYTES > buffer.size) {
+            throw IndexOutOfBoundsException("Attempt to read Q8_0 scale at offset ${finalScaleByteOffset.toInt()} for block $blockIndex in tensor '$name' is out of buffer bounds (0-${buffer.size - SHORT_SIZE_BYTES}). DataOffset: $dataOffset, BlockByteOffset: $blockByteOffset.")
+        }
+
+        val scaleBits = buffer.getShortLe(finalScaleByteOffset.toInt())
+        return halfToFloat(scaleBits)
+    }
+
+    /**
+     * Retrieves a single quantized weight (Int8/Byte) from a specific block in a Q8_0 tensor.
+     * @param graphAllocator The graph allocator holding the buffer.
+     * @param blockIndex The 0-based index of the block.
+     * @param itemIndexInBlock The 0-based index of the weight within the block (0 to QK8_0 - 1).
+     * @return The quantized weight as a Byte.
+     */
+    fun getQ8_0Weight(graphAllocator: GGMLGraphAllocator, blockIndex: Int, itemIndexInBlock: Int): Byte {
+        require(type == GGMLType.Q8_0) { "Tensor type must be Q8_0 to get weight." }
+        val numBlocks = getNumBlocks()
+        require(blockIndex >= 0 && blockIndex < numBlocks) { "blockIndex $blockIndex out of bounds for $numBlocks blocks in tensor '$name'." }
+        require(itemIndexInBlock >= 0 && itemIndexInBlock < QK8_0) { "itemIndexInBlock $itemIndexInBlock out of bounds (0-${QK8_0 -1}) for Q8_0 block in tensor '$name'."}
+
+        val blockByteOffset = blockIndex.toULong() * type.byteSize // type.byteSize is block size for Q8_0
+        val qsArrayBaseOffsetInBlock = 2uL // The F16 scale takes the first 2 bytes of the block
+        val finalWeightByteOffset = dataOffset + blockByteOffset + qsArrayBaseOffsetInBlock + itemIndexInBlock.toULong()
+
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId. Ensure graphAllocator.buffers is populated for tensor '$name'.")
+
+        if (finalWeightByteOffset.toInt() < 0 || finalWeightByteOffset.toInt() + Byte.SIZE_BYTES > buffer.size) {
+             throw IndexOutOfBoundsException("Attempt to read Q8_0 weight at offset ${finalWeightByteOffset.toInt()} for block $blockIndex, item $itemIndexInBlock in tensor '$name' is out of buffer bounds (0-${buffer.size - Byte.SIZE_BYTES}). DataOffset: $dataOffset, BlockByteOffset: $blockByteOffset, ItemOffset: $qsArrayBaseOffsetInBlock + $itemIndexInBlock.")
+        }
+        return buffer[finalWeightByteOffset.toInt()]
+    }
+
+    // --- Q4_0 Accessors ---
+
+    /**
+     * Retrieves the F16 scale for a specific block in a Q4_0 quantized tensor.
+     * @param graphAllocator The graph allocator holding the buffer.
+     * @param blockIndex The 0-based index of the block.
+     * @return The scale value as a Float.
+     */
+    fun getQ4_0BlockScale(graphAllocator: GGMLGraphAllocator, blockIndex: Int): Float {
+        require(type == GGMLType.Q4_0) { "Tensor type must be Q4_0 to get block scale." }
+        val numBlocks = getNumBlocks()
+        require(blockIndex >= 0 && blockIndex < numBlocks) { "blockIndex $blockIndex out of bounds for $numBlocks blocks in tensor '$name'." }
+
+        // type.byteSize for Q4_0 is the size of one block (e.g., 18 bytes)
+        val blockByteOffset = blockIndex.toULong() * type.byteSize
+        val finalScaleByteOffset = dataOffset + blockByteOffset
+
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId for tensor '$name'.")
+
+        // The scale is the first F16 (2 bytes) in the block
+        if (finalScaleByteOffset.toInt() < 0 || finalScaleByteOffset.toInt() + SHORT_SIZE_BYTES > buffer.size) {
+            throw IndexOutOfBoundsException("Attempt to read Q4_0 scale at offset ${finalScaleByteOffset.toInt()} for block $blockIndex in tensor '$name' is out of buffer bounds (0-${buffer.size - SHORT_SIZE_BYTES}). DataOffset: $dataOffset, BlockByteOffset: $blockByteOffset.")
+        }
+
+        val scaleBits = buffer.getShortLe(finalScaleByteOffset.toInt())
+        return halfToFloat(scaleBits)
+    }
+
+    /**
+     * Retrieves a single 4-bit quantized weight (nibble) from a specific block in a Q4_0 tensor.
+     * The returned Byte contains the raw 4-bit value (0-15).
+     * @param graphAllocator The graph allocator holding the buffer.
+     * @param blockIndex The 0-based index of the block.
+     * @param itemIndexInBlock The 0-based index of the weight within the block (0 to QK4_0 - 1).
+     * @return The quantized 4-bit weight as a Byte (value 0-15).
+     */
+    fun getQ4_0NibbleWeight(graphAllocator: GGMLGraphAllocator, blockIndex: Int, itemIndexInBlock: Int): Byte {
+        require(type == GGMLType.Q4_0) { "Tensor type must be Q4_0 to get nibble weight." }
+        val numBlocks = getNumBlocks()
+        require(blockIndex >= 0 && blockIndex < numBlocks) { "blockIndex $blockIndex out of bounds for $numBlocks blocks in tensor '$name'." }
+        require(itemIndexInBlock >= 0 && itemIndexInBlock < QK4_0) { "itemIndexInBlock $itemIndexInBlock out of bounds (0-${QK4_0 -1}) for Q4_0 block in tensor '$name'."}
+
+        val blockByteOffset = blockIndex.toULong() * type.byteSize
+        val qsArrayBaseOffsetInBlock = 2uL // The F16 scale takes the first 2 bytes
+        val byteContainingNibbleIndex = itemIndexInBlock / 2 // Each byte stores two 4-bit nibbles
+
+        val finalByteToReadOffset = dataOffset + blockByteOffset + qsArrayBaseOffsetInBlock + byteContainingNibbleIndex.toULong()
+
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId for tensor '$name'.")
+
+        if (finalByteToReadOffset.toInt() < 0 || finalByteToReadOffset.toInt() + Byte.SIZE_BYTES > buffer.size) {
+             throw IndexOutOfBoundsException("Attempt to read Q4_0 nibble weight byte at offset ${finalByteToReadOffset.toInt()} for block $blockIndex, item $itemIndexInBlock in tensor '$name' is out of buffer bounds (0-${buffer.size - Byte.SIZE_BYTES}).")
+        }
+        val packedByte = buffer[finalByteToReadOffset.toInt()]
+
+        val nibble = if (itemIndexInBlock % 2 == 0) {
+            packedByte.toInt() and 0x0F // First item in the byte (lower 4 bits)
+        } else {
+            (packedByte.toInt() ushr 4) and 0x0F // Second item in the byte (upper 4 bits)
+        }
+        return nibble.toByte()
+    }
+
+    // --- Q4_1 Accessors ---
+
+    /**
+     * Retrieves the F16 scale ('d') for a specific block in a Q4_1 quantized tensor.
+     */
+    fun getQ4_1BlockScale(graphAllocator: GGMLGraphAllocator, blockIndex: Int): Float {
+        require(type == GGMLType.Q4_1) { "Tensor type must be Q4_1 to get block scale 'd'." }
+        val numBlocks = getNumBlocks()
+        require(blockIndex >= 0 && blockIndex < numBlocks) { "blockIndex $blockIndex out of bounds for $numBlocks blocks in tensor '$name'." }
+
+        val blockByteOffset = blockIndex.toULong() * type.byteSize // type.byteSize for Q4_1 is 20 bytes
+        val finalScaleByteOffset = dataOffset + blockByteOffset // Scale 'd' is the first F16
+
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId for tensor '$name'.")
+
+        if (finalScaleByteOffset.toInt() < 0 || finalScaleByteOffset.toInt() + SIZE_BYTES > buffer.size) {
+            throw IndexOutOfBoundsException("Attempt to read Q4_1 scale 'd' at offset ${finalScaleByteOffset.toInt()} for block $blockIndex in tensor '$name' is out of buffer bounds (0-${buffer.size - SIZE_BYTES}).")
+        }
+
+        val scaleBits = buffer.getShortLe(finalScaleByteOffset.toInt())
+        return halfToFloat(scaleBits)
+    }
+
+    /**
+     * Retrieves the F16 min value ('m') for a specific block in a Q4_1 quantized tensor.
+     */
+    fun getQ4_1BlockMin(graphAllocator: GGMLGraphAllocator, blockIndex: Int): Float {
+        require(type == GGMLType.Q4_1) { "Tensor type must be Q4_1 to get block min 'm'." }
+        val numBlocks = getNumBlocks()
+        require(blockIndex >= 0 && blockIndex < numBlocks) { "blockIndex $blockIndex out of bounds for $numBlocks blocks in tensor '$name'." }
+
+        val blockByteOffset = blockIndex.toULong() * type.byteSize
+        val minOffsetWithinBlock = SIZE_BYTES.toULong() // Min 'm' is the second F16 (after the scale 'd')
+        val finalMinByteOffset = dataOffset + blockByteOffset + minOffsetWithinBlock
+
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId for tensor '$name'.")
+
+        if (finalMinByteOffset.toInt() < 0 || finalMinByteOffset.toInt() + SIZE_BYTES > buffer.size) {
+            throw IndexOutOfBoundsException("Attempt to read Q4_1 min 'm' at offset ${finalMinByteOffset.toInt()} for block $blockIndex in tensor '$name' is out of buffer bounds (0-${buffer.size - SIZE_BYTES}).")
+        }
+
+        val minBits = buffer.getShortLe(finalMinByteOffset.toInt())
+        return halfToFloat(minBits)
+    }
+
+    /**
+     * Retrieves a single 4-bit quantized weight (nibble) from a specific block in a Q4_1 tensor.
+     * The returned Byte contains the raw 4-bit value (0-15).
+     */
+    fun getQ4_1NibbleWeight(graphAllocator: GGMLGraphAllocator, blockIndex: Int, itemIndexInBlock: Int): Byte {
+        require(type == GGMLType.Q4_1) { "Tensor type must be Q4_1 to get nibble weight." }
+        val numBlocks = getNumBlocks()
+        require(blockIndex >= 0 && blockIndex < numBlocks) { "blockIndex $blockIndex out of bounds for $numBlocks blocks in tensor '$name'." }
+        require(itemIndexInBlock >= 0 && itemIndexInBlock < QK4_1) { "itemIndexInBlock $itemIndexInBlock out of bounds (0-${QK4_1 -1}) for Q4_1 block in tensor '$name'."}
+
+        val blockByteOffset = blockIndex.toULong() * type.byteSize
+        val qsBaseOffsetWithinBlock = (2 * SIZE_BYTES).toULong() // Weights start after two F16s (d and m)
+        val byteContainingNibbleIndex = itemIndexInBlock / 2
+
+        val finalByteToReadOffset = dataOffset + blockByteOffset + qsBaseOffsetWithinBlock + byteContainingNibbleIndex.toULong()
+
+        val buffer = graphAllocator.buffers[bufferId]
+            ?: throw IllegalStateException("Tensor buffer not found for bufferId $bufferId for tensor '$name'.")
+
+        if (finalByteToReadOffset.toInt() < 0 || finalByteToReadOffset.toInt() + Byte.SIZE_BYTES > buffer.size) {
+             throw IndexOutOfBoundsException("Attempt to read Q4_1 nibble weight byte at offset ${finalByteToReadOffset.toInt()} for block $blockIndex, item $itemIndexInBlock in tensor '$name' is out of buffer bounds.")
+        }
+        val packedByte = buffer[finalByteToReadOffset.toInt()]
+
+        val nibble = if (itemIndexInBlock % 2 == 0) {
+            packedByte.toInt() and 0x0F // First item (lower 4 bits)
+        } else {
+            (packedByte.toInt() ushr 4) and 0x0F // Second item (upper 4 bits)
+        }
+        return nibble.toByte()
+    }
+}
 
 /**
  * Scratch buffer for temporary storage

--- a/src/nativeMain/kotlin/ai/solace/llamakotlin/core/NumericConversions.kt
+++ b/src/nativeMain/kotlin/ai/solace/llamakotlin/core/NumericConversions.kt
@@ -1,0 +1,124 @@
+package ai.solace.llamakotlin.core
+
+// Half/Float conversion routines.
+
+/**
+ * Converts a 16-bit half-precision float to a 32-bit single-precision float.
+ * Based on public domain code by Fabian "ryg" Giesen and others.
+ */
+internal fun halfToFloat(h_bits: Short): Float {
+    val h = h_bits.toInt() and 0xFFFF // Ensure we're working with 16 bits, unsigned
+
+    val signMaskF32 = 0x80000000
+    val f32Infinity = 0x7F800000 // Positive infinity in F32
+
+    val hSign = (h ushr 15)
+    val hExp = (h ushr 10) and 0x1F
+    val hMant = h and 0x03FF
+
+    if (hExp == 0) { // Denormalized or zero
+        if (hMant == 0) { // Zero
+            return Float.fromBits(hSign shl 31)
+        } else { // Denormalized F16; convert to normalized F32
+            var mant = hMant
+            var exp = hExp
+            // Normalize: shift mantissa left until the leading bit is 1
+            while ((mant and 0x0400) == 0) { // 0x0400 is 10th bit (implicit 1 for F16 normalized)
+                mant = mant shl 1
+                exp-- // Adjust exponent downwards
+            }
+            // Remove the implicit leading 1 from mantissa (which is now explicit)
+            mant = mant and 0x03FF
+            // Adjusted exponent for F32: (F16 denorm exp is effectively -14)
+            // F32 exp = (exp + 1) - 15 (F16 bias) + 127 (F32 bias)
+            val f32Exp = (exp + 1) + (127 - 15)
+            val f32Mant = mant shl 13 // Align F16 10-bit mantissa to F32 23-bit
+            return Float.fromBits((hSign shl 31) or (f32Exp shl 23) or f32Mant)
+        }
+    } else if (hExp == 0x1F) { // Infinity or NaN
+        if (hMant == 0) { // Infinity
+            return Float.fromBits((hSign shl 31) or f32Infinity)
+        } else { // NaN
+            // Propagate NaN payload (hMant) to F32. Make it a quiet NaN.
+            // A common way is to set MSB of mantissa. F32 NaN: exp all 1s, mant non-zero.
+            return Float.fromBits((hSign shl 31) or f32Infinity or (hMant shl 13) or (1 shl 22)) // set a high bit in mantissa for qNaN
+        }
+    } else { // Normalized F16
+        val f32Sign = hSign shl 31
+        // F32 exp = F16 exp - F16 bias + F32 bias
+        val f32Exp = (hExp - 15 + 127) shl 23
+        // F32 mant = F16 mant left shifted by (23 - 10) = 13 bits
+        val f32Mant = hMant shl 13
+        return Float.fromBits(f32Sign or f32Exp or f32Mant)
+    }
+}
+
+/**
+ * Converts a 32-bit single-precision float to a 16-bit half-precision float.
+ * Implements Round-to-Nearest-Ties-to-Even.
+ * Based on public domain code by Fabian "ryg" Giesen (gist:2156668).
+ */
+internal fun floatToHalf(f_val: Float): Short {
+    val f32bits = f_val.toRawBits()
+    val fSign = (f32bits ushr 16) and 0x8000 // F16 sign bit (already shifted)
+    val absF = f32bits and 0x7FFFFFFF // Absolute value of F32
+
+    // Handle special cases
+    if (absF > 0x47FFEFFFU) { // F32 value is too large for F16 normal => F16 Inf or NaN
+        // NaN if F32 mantissa is non-zero, else Inf
+        val mantissaIsNonZero = (absF and 0x007FFFFFU) != 0
+        // F16 Inf/NaN: exp all 1s (0x1F for 5 bits -> 0x7C00 when shifted)
+        // For NaN, set MSB of mantissa (e.g., 0x0200 for F16) or any non-zero pattern
+        return (fSign or 0x7C00 or if (mantissaIsNonZero) 0x0200 else 0).toShort()
+    }
+
+    if (absF < 0x38800000U) { // F32 value is too small for F16 normal => F16 denormal or zero
+        // Convert F32 to F16 denormal
+        // Add implicit F32 '1' bit to mantissa
+        val fMant = (absF and 0x007FFFFFU) or 0x00800000U
+        // Calculate F16 denormal shift amount
+        // F32 exp is (absF ushr 23). Denormal F16 exp is effectively -14.
+        // Shift needed = 24 (F32 mant+implicit_1 bits) - (10 (F16 mant bits) + ( (absF ushr 23) - 127 (F32 bias) - (-14 (F16 denorm_exp)) ) )
+        // shift = 24 - (10 + ( (absF ushr 23) - 113) ) = 24 - 10 - (absF ushr 23) + 113 = 127 - (absF ushr 23)
+        val shift = 127 - (absF ushr 23) // Number of positions to shift right to align for F16 denormal mantissa
+
+        val hMant = if (shift < 24) (fMant ushr shift) else 0
+
+        // Rounding (RTNE for denormals requires checking bits shifted out)
+        val roundBits = fMant and ((1U shl shift) - 1U) // Bits lost
+        // Tie-breaking: if exactly halfway, round to even (LSB of hMant is 0 after rounding)
+        // Threshold for rounding up is halfway mark (1 << (shift - 1))
+        if (roundBits > (1U shl (shift - 1)) || (roundBits == (1U shl (shift - 1)) && (hMant and 1) != 0)) {
+           var h_temp = hMant + 1
+           // If rounding caused overflow into implicit leading bit of a normal number
+           if(h_temp == 0x0400) { // 0x0400 is 1024, meaning it became 1.0 * 2^(exp_min_norm_f16)
+               return (fSign or (1 shl 10)).toShort() // Smallest normalized F16
+           }
+           return (fSign or h_temp).toShort()
+        }
+        return (fSign or hMant).toShort()
+    }
+
+    // Handle normalized F16
+    // Shift and mask F32 exponent and mantissa to F16 form
+    // F32 exp bias 127, F16 exp bias 15. Diff = 112.
+    // F16 exp = (F32 exp - 112)
+    // F32 mantissa has 23 bits, F16 has 10. Diff = 13.
+    val hExp = ((absF ushr 23) - 112) shl 10 // Shifted F16 exponent
+    var hMant = (absF and 0x007FFFFFU) ushr 13 // Shifted F16 mantissa
+
+    // Rounding for normalized numbers (RTNE)
+    // Check the MSB of the bits that were shifted out (the rounding bit)
+    if ((absF and 0x00001000U) != 0U) { // If rounding bit is 1 (0x1000 is 2^12, MSB of 13 shifted bits)
+        // Check for tie-breaking (if remaining shifted bits are zero AND LSB of hMant is 1)
+        if ((absF and 0x00000FFFU) != 0U || (hMant and 1U) != 0U) {
+            hMant++
+            if (hMant == 0x0400U) { // Mantissa overflowed to 1024
+                hMant = 0U // Reset mantissa
+                // Increment exponent (already shifted)
+                return (fSign or (hExp + (1 shl 10)) or hMant).toShort()
+            }
+        }
+    }
+    return (fSign or hExp or hMant).toShort()
+}

--- a/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLAllocTest.kt
+++ b/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLAllocTest.kt
@@ -1,0 +1,515 @@
+package ai.solace.llamakotlin.core
+
+import kotlin.test.*
+
+// Assuming GGML_MAX_DIMS and GGMLType are accessible from this test package
+// For example, by being in the same module or via appropriate imports.
+// internal const val GGML_MAX_DIMS = 4 // Define if not accessible otherwise for tests
+
+class GGMLAllocTest {
+
+    private fun createDummyTensor(name: String = "dummy", type: GGMLType = GGMLType.F32): GGMLTensor {
+        val tensor = GGMLTensor(type = type) // ne defaults to [0,0,0,0]
+        tensor.name = name
+        // For tests, we mainly care about size, not ne/nb structure unless specifically testing views.
+        // The allocator uses the size passed to allocate(), not from tensor.ne/nb directly.
+        // However, for completeness if any part of allocator might inspect ne/nb:
+        tensor.ne = LongArray(GGML_MAX_DIMS) { 1L } // Treat as scalar for simplicity of ne/nb
+        if (type.byteSize > 0u) {
+            tensor.nb[0] = type.byteSize
+            for (i in 1 until GGML_MAX_DIMS) {
+                tensor.nb[i] = tensor.nb[i-1] * tensor.ne[i-1].toULong() // Will be type.byteSize for all nb if ne is all 1s
+            }
+        }
+        return tensor
+    }
+
+    private val dummyTensorF32 = createDummyTensor("tF32", GGMLType.F32) // size 4
+    // private val dummyTensorI16 = createDummyTensor("tI16", GGMLType.I16) // size 2 // Not used in current tests explicitly
+
+    // --- GGMLDynTensorAllocator Tests End ---
+
+    // --- GGMLGraphAllocator Tests Start ---
+
+    private fun setupTensorForGraph(
+        name: String,
+        type: GGMLType,
+        dims: LongArray,
+        op: GGMLOp = GGMLOp.NONE,
+        isOutput: Boolean = false
+    ): GGMLTensor {
+        val tensor = GGMLTensor(type = type)
+        tensor.name = name
+        tensor.op = op
+        if (isOutput) {
+            tensor.flags = tensor.flags or GGML_TENSOR_FLAG_OUTPUT
+        }
+
+        // Ensure dims is GGML_MAX_DIMS long
+        if (dims.size < GGML_MAX_DIMS) {
+            tensor.ne = LongArray(GGML_MAX_DIMS) { 1L }
+            dims.copyInto(tensor.ne, 0, 0, dims.size)
+        } else if (dims.size == GGML_MAX_DIMS) {
+            tensor.ne = dims.copyOf()
+        } else {
+            throw IllegalArgumentException("Dimensions array size ${dims.size} exceeds GGML_MAX_DIMS $GGML_MAX_DIMS")
+        }
+
+        // Simplified stride calculation for test setup
+        if (type.byteSize > 0u) {
+            tensor.nb[0] = type.byteSize
+            for (i in 1 until GGML_MAX_DIMS) {
+                tensor.nb[i] = tensor.nb[i-1] * (if (tensor.ne[i-1] > 0) tensor.ne[i-1].toULong() else 1uL)
+            }
+        } else { // For types with 0 byteSize (like quantized), set nb to 0 or based on some convention if needed for tests
+            tensor.nb.fill(0uL)
+        }
+        tensor.data = null // Ensure data is null for graph allocation tests
+        return tensor
+    }
+
+
+    // Helper to calculate the padded size of a requested allocation based on GGMLDynTensorAllocator's logic
+    private fun calculatePaddedSize(requestedSize: ULong, alignment: UInt = 16u): ULong {
+        // Copied from alignedOffset in GGMLAlloc.kt, but ensuring it matches the allocator's internal padding logic
+        // which is typically just aligning the offset, and the block size becomes aligned implicitly.
+        // The allocator allocates a block starting at an aligned offset. The size of this block is effectively padded.
+        // No, the allocator takes the requested size, aligns IT, then finds a block.
+        // So, calculatePaddedSize should be alignedOffset(requestedSize, alignment) from the perspective of block size needed.
+        // Let's re-verify GGMLDynTensorAllocator.allocate internal logic for size padding.
+        // It does: `val alignedSize = alignedOffset(size, alignment)`
+        return alignedOffset(requestedSize, alignment.toUInt()) // Use the actual alignedOffset function
+    }
+
+    // Actual alignedOffset function as defined in GGMLAlloc.kt for testing purposes
+    private fun alignedOffset(offset: ULong, alignment: UInt): ULong {
+        assert(alignment > 0u && (alignment and (alignment - 1u)) == 0u)
+        val align = (alignment - (offset % alignment)) % alignment
+        return offset + align
+    }
+
+
+    @Test
+    fun testInitialState() {
+        val allocator = GGMLDynTensorAllocator(bufferSize = 1024uL)
+        assertEquals(0uL, allocator.getMaxSize(), "Initial maxSize should be 0")
+        assertEquals(1, allocator.freeBlocks.size, "Should have one initial free block")
+        assertEquals(0uL, allocator.freeBlocks[0].offset, "Initial free block offset should be 0")
+        assertEquals(1024uL, allocator.freeBlocks[0].size, "Initial free block size should match bufferSize")
+    }
+
+    @Test
+    fun testSingleAllocationAndMaxSize() {
+        val allocator = GGMLDynTensorAllocator(bufferSize = 1024uL, alignment = 16u)
+        val size1 = 100uL
+        val paddedSize1 = calculatePaddedSize(size1, 16u) // 112uL
+
+        val offset1 = allocator.allocate(size1, dummyTensorF32)
+        assertEquals(0uL, offset1, "Offset of first allocation should be 0")
+        assertEquals(paddedSize1, allocator.getMaxSize(), "maxSize after first allocation")
+
+        val size2 = 200uL
+        val paddedSize2 = calculatePaddedSize(size2, 16u) // 208uL
+        val offset2 = allocator.allocate(size2, dummyTensorF32)
+        // Offset of second should be at offset of first (0) + paddedSize of first
+        assertEquals(paddedSize1, offset2, "Offset of second allocation should be after first padded block")
+        assertEquals(paddedSize1 + paddedSize2, allocator.getMaxSize(), "maxSize after second allocation")
+    }
+
+    @Test
+    fun testAllocationExceedsBuffer() {
+        val allocator = GGMLDynTensorAllocator(bufferSize = 100uL, alignment = 16u) // Buffer 100
+        val size1 = 90uL
+        val paddedSize1 = calculatePaddedSize(size1, 16u) // 96uL
+        allocator.allocate(size1, dummyTensorF32) // Allocates 0-95. MaxSize = 96. Free block: offset 96, size 4
+
+        assertFailsWith<IllegalStateException>("Should fail if allocation exceeds buffer size") {
+            // Requesting 10uL, padded is 16uL. The remaining free block (size 4) is too small.
+            allocator.allocate(10uL, dummyTensorF32)
+        }
+    }
+
+    @Test
+    fun testAllocationExceedsBufferImmediately() {
+        val allocator = GGMLDynTensorAllocator(bufferSize = 100uL)
+        assertFailsWith<IllegalStateException>("Should fail if allocation exceeds buffer size") {
+            allocator.allocate(120uL, dummyTensorF32)
+        }
+    }
+
+    @Test
+    fun testFreeAndReuseExactSize() {
+        val allocator = GGMLDynTensorAllocator(bufferSize = 1024uL, alignment = 16u)
+        val size1 = 100uL
+        val paddedSize1 = calculatePaddedSize(size1, 16u)
+        val size2 = 200uL
+        val paddedSize2 = calculatePaddedSize(size2, 16u)
+
+        val offset1 = allocator.allocate(size1, dummyTensorF32)
+        val offset2 = allocator.allocate(size2, dummyTensorF32)
+
+        // Free the second block
+        allocator.freeTensor(offset2, size2, dummyTensorF32)
+
+        // Allocate same size as freed block
+        val offset3 = allocator.allocate(size2, createDummyTensor("t3"))
+        assertEquals(offset2, offset3, "Should reuse the exactly sized freed block")
+        assertEquals(paddedSize1 + paddedSize2, allocator.getMaxSize(), "MaxSize should remain the same")
+    }
+
+    @Test
+    fun testFreeAndReuseSmallerThanFreed() {
+        val allocator = GGMLDynTensorAllocator(bufferSize = 1024uL, alignment = 16u)
+        val size1 = 100uL
+        val paddedSize1 = calculatePaddedSize(size1, 16u)
+        val sizeToFree = 200uL
+        val paddedSizeToFree = calculatePaddedSize(sizeToFree, 16u)
+
+        val smallerSizeAlloc = 50uL
+        val paddedSmallerSizeAlloc = calculatePaddedSize(smallerSizeAlloc, 16u)
+
+        val offset1 = allocator.allocate(size1, dummyTensorF32)
+        val offsetToFree = allocator.allocate(sizeToFree, dummyTensorF32)
+
+        allocator.freeTensor(offsetToFree, sizeToFree, dummyTensorF32)
+
+        val offsetSmaller = allocator.allocate(smallerSizeAlloc, createDummyTensor("ts1"))
+        assertEquals(offsetToFree, offsetSmaller, "Should use start of the freed block")
+
+        // Check that the remaining part of the freed block is correct
+        // Expected: one block from 0 to paddedSize1-1 (used)
+        //           one block from offsetToFree to offsetToFree+paddedSmallerSizeAlloc-1 (used by ts1)
+        //           one free block from offsetToFree+paddedSmallerSizeAlloc to offsetToFree+paddedSizeToFree-1
+        //           one free block at the end of the buffer
+        val expectedRemainingFreeBlockOffset = offsetToFree + paddedSmallerSizeAlloc
+        val expectedRemainingFreeBlockSize = paddedSizeToFree - paddedSmallerSizeAlloc
+
+        val foundRemainingBlock = allocator.freeBlocks.find { it.offset == expectedRemainingFreeBlockOffset && it.size == expectedRemainingFreeBlockSize }
+        assertNotNull(foundRemainingBlock, "Should find a free block representing the remainder of the split block.")
+
+        assertEquals(paddedSize1 + paddedSizeToFree, allocator.getMaxSize(), "MaxSize should not change")
+    }
+
+    @Test
+    fun testFreeAndMergeAdjacentBlocks() {
+        // Use alignment = 1u to make sizes exact and predictable without padding interference for this test
+        val allocator = GGMLDynTensorAllocator(alignment = 1u, bufferSize = 1024uL)
+        val s = 100uL
+        val t1 = createDummyTensor("t1"); val t2 = createDummyTensor("t2"); val t3 = createDummyTensor("t3")
+
+        val off1 = allocator.allocate(s, t1) // 0-99
+        assertEquals(0uL, off1)
+        val off2 = allocator.allocate(s, t2) // 100-199
+        assertEquals(100uL, off2)
+        allocator.allocate(s, t3)      // 200-299 // t_placeholder
+
+        assertEquals(1, allocator.freeBlocks.size, "One free block should remain at the end initially")
+        assertEquals(300uL, allocator.getMaxSize())
+
+        allocator.freeTensor(off1, s, t1) // Free [0-99]. Free blocks: {[0,100], [300,724]}
+        assertEquals(2, allocator.freeBlocks.size)
+        assertTrue(allocator.freeBlocks.any { it.offset == 0uL && it.size == 100uL })
+
+
+        allocator.freeTensor(off2, s, t2) // Free [100-199]. Should merge with [0-99].
+                                          // Free blocks: {[0,200], [300,724]}
+        assertEquals(2, allocator.freeBlocks.size, "Freeing adjacent block should merge blocks.")
+        assertTrue(allocator.freeBlocks.any { it.offset == 0uL && it.size == 200uL }, "Merged block [0,200] not found.")
+
+        val mergedAllocOffset = allocator.allocate(150uL, createDummyTensor("merged"))
+        assertEquals(0uL, mergedAllocOffset, "Should use the merged block at offset 0")
+        // After allocation: Used [0-149]. Free blocks: {[150,50], [300,724]}
+        assertEquals(2, allocator.freeBlocks.size)
+        assertTrue(allocator.freeBlocks.any { it.offset == 150uL && it.size == 50uL })
+    }
+
+    @Test
+    fun testFreeMergeMoreComplex() {
+        val allocator = GGMLDynTensorAllocator(alignment = 1u, bufferSize = 500uL)
+        val s = 100uL
+        val t1 = createDummyTensor("t1"); val t2 = createDummyTensor("t2");
+        val t3 = createDummyTensor("t3"); val t4 = createDummyTensor("t4")
+        val t5 = createDummyTensor("t5")
+
+        val off1 = allocator.allocate(s, t1) // 0-99
+        val off2 = allocator.allocate(s, t2) // 100-199
+        val off3 = allocator.allocate(s, t3) // 200-299
+        allocator.allocate(s, t4)      // 300-399. MaxSize = 400. Free: [400, 100]
+
+        allocator.freeTensor(off2, s, t2) // Free [100-199]. Free: {[100,100], [400,100]}
+        allocator.freeTensor(off1, s, t1) // Free [0-99]. Merges with [100-199]. Free: {[0,200], [400,100]}
+
+        assertEquals(2, allocator.freeBlocks.size)
+        assertTrue(allocator.freeBlocks.any { it.offset == 0uL && it.size == 200uL })
+
+        val off5 = allocator.allocate(150uL, t5) // Uses [0-149] from [0,200].
+        assertEquals(0uL, off5, "t5 should be allocated at offset 0 from merged block")
+        // Free blocks: {[150,50], [400,100]}
+        assertEquals(2, allocator.freeBlocks.size)
+        assertTrue(allocator.freeBlocks.any { it.offset == 150uL && it.size == 50uL })
+
+
+        allocator.freeTensor(off3,s,t3) // Free [200-299].
+                                        // Free blocks: {[150,50], [200,100], [400,100]}.
+                                        // Block [150,50] and [200,100] should merge.
+                                        // Expected merge: if block B is freed and B.offset == A.offset + A.size, A absorbs B.
+                                        // If block B is freed and A.offset == B.offset + B.size, B absorbs A.
+                                        // Here, freeing [200,100]. Previous block is [150,50]. Not adjacent by start.
+                                        // Next block is [400,100]. Not adjacent by end.
+                                        // It seems my merge logic understanding for this case might be off or the implementation detail matters.
+                                        // The code tries to merge with previous and next blocks in the list if they become adjacent.
+                                        // After freeing [200,100], it should be inserted.
+                                        // Freeing [200,100]. Free list: {[150,50], [400,100]}
+                                        // Insert [200,100] -> list: {[150,50], [200,100], [400,100]} (sorted by offset)
+                                        // Check if [200,100] merges with [150,50] (no: 150+50 != 200)
+                                        // Check if [200,100] merges with [400,100] (no: 200+100 != 400)
+                                        // So, 3 free blocks expected.
+        assertEquals(3, allocator.freeBlocks.size, "Should have 3 distinct free blocks after freeing t3.")
+        assertTrue(allocator.freeBlocks.any { it.offset == 200uL && it.size == 100uL })
+
+        // Now, if we free the block at 150, it *should* merge with 200.
+        // To test this, let's allocate something in [400,100] to keep it separate.
+        allocator.allocate(50uL, createDummyTensor("t_filler_end")) // uses [400-449]
+        // Free blocks: {[150,50], [200,100], [450,50]}
+
+        // To free the block at 150, we need a tensor that was allocated there.
+        // We don't have one directly. Let's re-evaluate the test logic slightly.
+        // The goal is to see if freeing a block makes it merge with a subsequent block.
+        // Current state: Free: {[150,50], [200,100], [450,50]}
+        // Let's try to allocate 150uL, it should take [150,50] and then [200,100] -> split [200,100]
+
+        // Simpler test for merge with next:
+        allocator.reset(500uL)
+        val oA = allocator.allocate(100uL, createDummyTensor("A")) // 0-99
+        val oB = allocator.allocate(100uL, createDummyTensor("B")) // 100-199
+        val oC = allocator.allocate(100uL, createDummyTensor("C")) // 200-299
+        allocator.freeTensor(oA, 100uL, createDummyTensor("A")) // Free [0-99]
+        allocator.freeTensor(oC, 100uL, createDummyTensor("C")) // Free [200-299]
+        // Free blocks are now: [0,100], [200,100], [300,200]
+        assertEquals(3, allocator.freeBlocks.size)
+        allocator.freeTensor(oB, 100uL, createDummyTensor("B")) // Free [100-199]
+        // Should merge all three into [0,300]. Then [300,200] from end. Total 2 blocks.
+        // Freeing [100,100]:
+        // 1. Merges with [0,100] -> new block [0,200]
+        // 2. Then this new block [0,200] merges with [200,100] -> final [0,300]
+        assertEquals(2, allocator.freeBlocks.size, "All three adjacent freed blocks should merge.")
+        assertTrue(allocator.freeBlocks.any { it.offset == 0uL && it.size == 300uL })
+
+    }
+
+
+    @Test
+    fun testResetAllocator() {
+        val allocator = GGMLDynTensorAllocator(bufferSize = 1024uL, alignment = 16u)
+        allocator.allocate(100uL, dummyTensorF32)
+
+        val newBufferSize = 512uL
+        allocator.reset(newBufferSize)
+
+        assertEquals(0uL, allocator.getMaxSize(), "maxSize should be 0 after reset")
+        assertEquals(1, allocator.freeBlocks.size, "Should have one free block after reset")
+        assertEquals(newBufferSize, allocator.freeBlocks[0].size, "Free block size should be newBufferSize")
+
+        val sizeAfterReset = 50uL
+        val paddedSizeAfterReset = calculatePaddedSize(sizeAfterReset, 16u)
+        val offsetAfterReset = allocator.allocate(sizeAfterReset, dummyTensorF32)
+        assertEquals(0uL, offsetAfterReset, "First allocation after reset should start at 0")
+        assertEquals(paddedSizeAfterReset, allocator.getMaxSize(), "maxSize after allocation post-reset")
+
+        assertFailsWith<IllegalStateException>("Should fail if allocation exceeds new buffer size after reset") {
+            // Padded size of 449uL (requested) with 16u alignment is 464uL.
+            // 512 (buffer) - 64 (used by 50uL alloc) = 448 remaining. 464 > 448.
+            allocator.allocate(449uL, createDummyTensor("t_exceed"))
+        }
+    }
+
+    @Test
+    fun testReserveGraphSimple() {
+        val graphAllocator = GGMLGraphAllocator()
+        val graph = GGMLCGraph()
+
+        val tensorA = setupTensorForGraph("A", GGMLType.F32, longArrayOf(10))    // 10*4 = 40 bytes
+        val tensorB = setupTensorForGraph("B", GGMLType.I16, longArrayOf(5, 2)) // 5*2*2 = 20 bytes
+        val tensorC = setupTensorForGraph("C", GGMLType.I8, longArrayOf(3))     // 3*1 = 3 bytes
+
+        graph.leafs = arrayOf(tensorA, tensorB, tensorC)
+        graph.nLeafs = 3
+        graph.nodes = arrayOf(tensorA, tensorB, tensorC) // For simple reserve, nodes can be same as leafs
+        graph.nNodes = 3
+
+        // Default alignment is 16u
+        val paddedSizeA = calculatePaddedSize(40uL, 16u) // 48
+        val paddedSizeB = calculatePaddedSize(20uL, 16u) // 32
+        val paddedSizeC = calculatePaddedSize(3uL, 16u)  // 16
+        val expectedTotalSize = paddedSizeA + paddedSizeB + paddedSizeC // 48 + 32 + 16 = 96
+
+        graphAllocator.reserveGraph(graph)
+
+        // getBufferSize(0) gets the maxSize from the dynamic allocator, which includes padding for each allocation
+        assertEquals(expectedTotalSize, graphAllocator.getBufferSize(0), "Buffer size after reserveGraph not as expected")
+    }
+
+    @Test
+    fun testAllocateGraphBasic_TwoInputs_OneAddOutput() {
+        val graphAllocator = GGMLGraphAllocator()
+        val graph = GGMLCGraph()
+
+        val tensorA = setupTensorForGraph("A", GGMLType.F32, longArrayOf(10), op = GGMLOp.NONE)  // 40 bytes
+        val tensorB = setupTensorForGraph("B", GGMLType.F32, longArrayOf(10), op = GGMLOp.NONE)  // 40 bytes
+        val tensorC = setupTensorForGraph("C", GGMLType.F32, longArrayOf(10), op = GGMLOp.ADD, isOutput = true) // 40 bytes
+
+        tensorC.src[0] = tensorA
+        tensorC.src[1] = tensorB
+
+        graph.leafs = arrayOf(tensorA, tensorB)
+        graph.nLeafs = 2
+        graph.nodes = arrayOf(tensorA, tensorB, tensorC) // Order: A, B, then C
+        graph.nNodes = 3
+
+        graphAllocator.allocateGraph(graph)
+
+        val alignment = 16u // Default alignment in GGMLDynTensorAllocator
+        val paddedSizeA = calculatePaddedSize(40uL, alignment) // 48
+        val paddedSizeB = calculatePaddedSize(40uL, alignment) // 48
+        val paddedSizeC = calculatePaddedSize(40uL, alignment) // 48
+
+
+        assertNotNull(graphAllocator.tensorUsageMap[tensorA])
+        assertNotNull(graphAllocator.tensorUsageMap[tensorB])
+        assertNotNull(graphAllocator.tensorUsageMap[tensorC])
+
+        assertEquals(0, tensorA.bufferId, "Tensor A bufferId")
+        assertEquals(0uL, tensorA.dataOffset, "Tensor A dataOffset")
+
+        assertEquals(0, tensorB.bufferId, "Tensor B bufferId")
+        assertEquals(paddedSizeA, tensorB.dataOffset, "Tensor B dataOffset")
+
+        assertEquals(0, tensorC.bufferId, "Tensor C bufferId")
+        assertEquals(paddedSizeA + paddedSizeB, tensorC.dataOffset, "Tensor C dataOffset")
+        assertTrue(graphAllocator.tensorUsageMap[tensorC]!!.isOutputTensor, "Tensor C should be output")
+        assertTrue(graphAllocator.tensorUsageMap[tensorC]!!.ownsMemory, "Tensor C should own its memory")
+
+
+        val expectedTotalMaxSize = paddedSizeA + paddedSizeB + paddedSizeC
+        assertEquals(expectedTotalMaxSize, graphAllocator.tensorAllocators[0].getMaxSize(), "Allocator max size not as expected")
+    }
+
+
+    @Test
+    fun testAllocateGraphInplace() {
+        val graphAllocator = GGMLGraphAllocator()
+        val graph = GGMLCGraph()
+
+        val tensorInput = setupTensorForGraph("INPUT", GGMLType.F32, longArrayOf(10)) // 40 bytes
+        val tensorReluOut = setupTensorForGraph("RELU_OUT", GGMLType.F32, longArrayOf(10), op = GGMLOp.RELU, isOutput = true)
+
+        tensorReluOut.src[0] = tensorInput
+
+        graph.leafs = arrayOf(tensorInput)
+        graph.nLeafs = 1
+        // Order: INPUT, then RELU_OUT. This is important for inplace and freeing logic.
+        graph.nodes = arrayOf(tensorInput, tensorReluOut)
+        graph.nNodes = 2
+
+        // Ensure RELU is inplace for this test
+        assertTrue(GGMLOp.RELU.canBeInplace, "RELU op should be marked as canBeInplace for this test to be valid")
+
+        graphAllocator.allocateGraph(graph)
+
+        assertNotNull(graphAllocator.tensorUsageMap[tensorInput])
+        assertNotNull(graphAllocator.tensorUsageMap[tensorReluOut])
+
+        assertEquals(0, tensorInput.bufferId, "INPUT bufferId")
+        assertEquals(0uL, tensorInput.dataOffset, "INPUT dataOffset")
+
+        // RELU_OUT should reuse INPUT's memory
+        assertEquals(tensorInput.bufferId, tensorReluOut.bufferId, "RELU_OUT should reuse INPUT's bufferId")
+        assertEquals(tensorInput.dataOffset, tensorReluOut.dataOffset, "RELU_OUT should reuse INPUT's dataOffset")
+
+        assertTrue(graphAllocator.tensorUsageMap[tensorReluOut]!!.ownsMemory, "RELU_OUT should own the memory segment")
+        assertFalse(graphAllocator.tensorUsageMap[tensorInput]!!.ownsMemory, "INPUT should have relinquished memory ownership")
+        assertTrue(graphAllocator.tensorUsageMap[tensorReluOut]!!.isOutputTensor, "RELU_OUT is an output tensor")
+
+        val paddedSizeInput = calculatePaddedSize(40uL, 16u) // 48
+        assertEquals(paddedSizeInput, graphAllocator.tensorAllocators[0].getMaxSize(), "Allocator max size should be size of one tensor")
+    }
+
+    @Test
+    fun testAllocateGraphMemoryFreeing() {
+        val graphAllocator = GGMLGraphAllocator()
+        val graph = GGMLCGraph()
+        val alignment = 16u // Default
+
+        // Setup tensors
+        val tensorA = setupTensorForGraph("A", GGMLType.F32, longArrayOf(10)) // 40 bytes, padded 48
+        val tensorB = setupTensorForGraph("B", GGMLType.F32, longArrayOf(10)) // 40 bytes, padded 48
+        // Ensure ADD is NOT inplace for this test to make TEMP distinct.
+        // We can achieve this by making its output different or ensuring conditions aren't met,
+        // or by temporarily overriding canBeInplace (not clean for test).
+        // For this test, we assume ADD is not inplace or its conditions for inplace are not met.
+        // (e.g. if we were to add another child to A or B before TEMP is computed)
+        val tensorTemp = setupTensorForGraph("TEMP", GGMLType.F32, longArrayOf(10), op = GGMLOp.ADD)
+        val tensorOutput = setupTensorForGraph("OUTPUT", GGMLType.F32, longArrayOf(10), op = GGMLOp.RELU, isOutput = true)
+
+        tensorTemp.src[0] = tensorA
+        tensorTemp.src[1] = tensorB
+        tensorOutput.src[0] = tensorTemp
+
+        graph.leafs = arrayOf(tensorA, tensorB)
+        graph.nLeafs = 2
+        // Order: A, B, TEMP, OUTPUT
+        graph.nodes = arrayOf(tensorA, tensorB, tensorTemp, tensorOutput)
+        graph.nNodes = 4
+
+        val originalAddCanBeInplace = GGMLOp.ADD.canBeInplace
+        val originalReluCanBeInplace = GGMLOp.RELU.canBeInplace
+
+        // Force ADD to not be inplace for this test if it was marked as such
+        // This is a bit hacky for a test; ideally, the graph structure would ensure this.
+        // Forcing by temporarily changing enum state is not robust if tests run in parallel or state leaks.
+        // A better way is to ensure inplace conditions for ADD are not met (e.g. A or B has other children).
+        // For simplicity here, we rely on default ADD behavior or assume it won't be inplace.
+        // And ensure RELU is inplace.
+        if (!GGMLOp.RELU.canBeInplace) {
+            // This would be a test setup issue, not a library issue.
+            // For this test, we'll assume it's true or skip.
+            println("Warning: RELU not marked as canBeInplace, testAllocateGraphMemoryFreeing might not be fully valid.")
+        }
+
+
+        graphAllocator.allocateGraph(graph)
+
+        val paddedSizeA = calculatePaddedSize(40uL, alignment) // 48
+        val paddedSizeB = calculatePaddedSize(40uL, alignment) // 48
+        val paddedSizeTemp = calculatePaddedSize(40uL, alignment) // 48
+
+        assertEquals(0uL, tensorA.dataOffset, "Tensor A offset")
+        assertEquals(paddedSizeA, tensorB.dataOffset, "Tensor B offset")
+        assertEquals(paddedSizeA + paddedSizeB, tensorTemp.dataOffset, "Tensor TEMP offset")
+
+        // OUTPUT (RELU) should be inplace on TEMP
+        assertEquals(tensorTemp.dataOffset, tensorOutput.dataOffset, "Tensor OUTPUT should reuse TEMP's offset")
+
+        // Max size should be up to where TEMP/OUTPUT is.
+        // A (0-47), B (48-95), TEMP/OUTPUT (96-143)
+        assertEquals(paddedSizeA + paddedSizeB + paddedSizeTemp, graphAllocator.tensorAllocators[0].getMaxSize(), "Max size after graph allocation")
+
+        // Check if memory for A and B was freed (their numChildren would be 0)
+        // This is implicitly tested by trying to reallocate.
+        // The allocator's free list should now contain blocks for A and B.
+
+        val dynAlloc = graphAllocator.tensorAllocators[0]
+
+        // Try to allocate new tensors of same size as A and B
+        val newTensorX = setupTensorForGraph("X", GGMLType.F32, longArrayOf(10))
+        val newTensorY = setupTensorForGraph("Y", GGMLType.F32, longArrayOf(10))
+
+        val offsetX = dynAlloc.allocate(calculateTensorSize(newTensorX), newTensorX)
+        // First free block should be A's old space
+        assertEquals(tensorA.dataOffset, offsetX, "New tensor X should reuse A's freed memory")
+
+        val offsetY = dynAlloc.allocate(calculateTensorSize(newTensorY), newTensorY)
+        // Next free block should be B's old space
+        assertEquals(tensorB.dataOffset, offsetY, "New tensor Y should reuse B's freed memory")
+    }
+}

--- a/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLComputeOpsTest.kt
+++ b/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLComputeOpsTest.kt
@@ -1,0 +1,699 @@
+package ai.solace.llamakotlin.core
+
+import kotlin.math.* // Import all math functions
+import kotlin.test.*
+import kotlin.Short.Companion.SIZE_BYTES as SHORT_SIZE_BYTES
+
+
+class GGMLComputeOpsTest {
+
+    private lateinit var graphAllocator: GGMLGraphAllocator
+    private lateinit var testBuffer: ByteArray
+    private val bufferSize = 1 * 1024 * 1024 // 1MB
+
+    // Helper to calculate strides for a contiguous tensor
+    private fun calculateStrides(type: GGMLType, ne: LongArray, maxDims: Int = GGML_MAX_DIMS): ULongArray {
+        val nb = ULongArray(maxDims) { 0uL }
+        if (type.byteSize > 0uL) {
+            nb[0] = type.byteSize
+            if (maxDims > 1) {
+                for (d in 1 until maxDims) {
+                    // Use ne.getOrElse to handle cases where ne.size < d-1, default to 1 for element count
+                    val prevDimSize = ne.getOrElse(d - 1) { 1L }
+                    nb[d] = nb[d-1] * (if (prevDimSize > 0) prevDimSize.toULong() else 1uL)
+                }
+            }
+        }
+        return nb
+    }
+
+    // Helper to calculate tensor byte size
+    private fun calculateTensorByteSize(type: GGMLType, ne: LongArray): ULong {
+        if (type.byteSize == 0uL && type != GGMLType.COUNT && !type.name.startsWith("Q")) {
+             println("Warning: Calculating byte size for type ${type.name} with byteSize 0.")
+            return 0uL
+        }
+        var elements = 1UL
+        var validDimFound = false
+        for (i in ne.indices) { // Iterate only over provided dims in ne
+            if (ne[i] > 0L) {
+                elements *= ne[i].toULong()
+                validDimFound = true
+            } else if (ne[i] == 0L && elements != 0UL && validDimFound) { // A zero in a significant dimension nullifies size
+                return 0UL
+            }
+        }
+        // If no valid positive dimension found but ne is not empty (e.g. ne=[1,1,1,1] treated as scalar)
+        // or if ne was empty (elements still 1UL)
+        if (!validDimFound && ne.isNotEmpty() && ne.all { it <= 1L }) {
+            elements = 1UL // Scalar or effectively scalar
+        } else if (!validDimFound && ne.isEmpty()){
+            elements = 1UL // Treat as scalar if ne is completely empty
+        }
+
+        // For block types like Q8_0, byteSize is per block, numElements() is actual element count
+        if (type == GGMLType.Q8_0 && elements > 0uL) {
+            if (elements.toLong() % QK8_0 != 0L) {
+                println("Warning: Total elements $elements for Q8_0 is not divisible by block size $QK8_0.")
+            }
+            return (elements.toLong() / QK8_0).toULong() * type.byteSize
+        }
+
+        return elements * type.byteSize
+    }
+
+
+    @BeforeTest
+    fun setup() {
+        graphAllocator = GGMLGraphAllocator()
+        testBuffer = ByteArray(bufferSize)
+        // Ensure buffer and allocator lists are not empty before assignment
+        if (graphAllocator.buffers.isEmpty()) graphAllocator.buffers.add(null)
+        if (graphAllocator.tensorAllocators.isEmpty()) graphAllocator.tensorAllocators.add(GGMLDynTensorAllocator())
+
+        graphAllocator.buffers[0] = testBuffer
+        graphAllocator.tensorAllocators[0].reset(bufferSize.toULong())
+    }
+
+    // Helper to create a tensor and optionally initialize it with a sequence
+    private fun createAndInitTensor(
+        name: String,
+        type: GGMLType,
+        dims: LongArray, // Effective dimensions, e.g. longArrayOf(10) or longArrayOf(3,4)
+        dataOffset: ULong = 0uL,
+        bufferId: Int = 0,
+        fillSequence: Boolean = false,
+        startValue: Number = 0.0f,
+        step: Number = 1.0f
+    ): GGMLTensor {
+        val tensor = GGMLTensor(type = type)
+        tensor.name = name
+
+        // Pad ne to GGML_MAX_DIMS with 1s for unused dimensions
+        tensor.ne = LongArray(GGML_MAX_DIMS) { 1L }
+        dims.forEachIndexed { index, dimSize ->
+            if (index < GGML_MAX_DIMS) tensor.ne[index] = dimSize
+        }
+
+        tensor.nb = calculateStrides(type, tensor.ne)
+        tensor.bufferId = bufferId
+        tensor.dataOffset = dataOffset
+        tensor.data = null // Important: We are testing accessors on the shared buffer
+
+        // Use tensor.numElements() for calculating byte size for allocation check
+        val actualElementCount = tensor.numElements()
+        val tensorByteSizeForCheck = if (type == GGMLType.Q8_0) {
+            if (actualElementCount % QK8_0 != 0L) throw IllegalArgumentException("Q8_0 element count must be div by QK8_0")
+            (actualElementCount / QK8_0).toULong() * type.byteSize
+        } else {
+            actualElementCount.toULong() * type.byteSize
+        }
+
+        assertTrue(dataOffset + tensorByteSizeForCheck <= bufferSize.toULong(),
+            "Test tensor setup (offset $dataOffset + size $tensorByteSizeForCheck) for tensor ${tensor.name} " +
+            "type ${type.name} dims ${dims.joinToString()} (effective ne: ${tensor.ne.joinToString()}) exceeds buffer capacity ($bufferSize).")
+
+        if (fillSequence) {
+            val numElementsToFill = tensor.numElements().toInt()
+            var currentValue = startValue.toFloat()
+            val stepValue = step.toFloat()
+
+            // This direct write is for test setup convenience.
+            // Actual operations under test should use tensor.setX/getX accessors.
+            var writeOffset = tensor.dataOffset.toInt()
+
+            if (type == GGMLType.Q8_0) {
+                require(numElementsToFill % QK8_0 == 0) { "Q8_0 fill sequence requires numElements divisible by QK8_0" }
+                val numBlocks = numElementsToFill / QK8_0
+                val f32Block = FloatArray(QK8_0)
+                var elemIdx = 0
+                for (blockNum in 0 until numBlocks) {
+                    for (i in 0 until QK8_0) {
+                        f32Block[i] = startValue.toFloat() + (elemIdx++ * stepValue)
+                    }
+                    var amax = 0.0f
+                    for(v in f32Block) amax = maxOf(amax, abs(v))
+                    val scaleF32 = if (amax == 0.0f) 1.0f else amax / 127.0f
+                    val invScaleF32 = 1.0f / scaleF32
+                    val scaleF16Short = floatToHalf(scaleF32)
+
+                    testBuffer.setShortLe(writeOffset, scaleF16Short)
+                    writeOffset += SHORT_SIZE_BYTES
+                    for (fVal in f32Block) {
+                        val scaledVal = fVal * invScaleF32
+                        var iVal = round(scaledVal).toInt()
+                        iVal = iVal.coerceIn(-128, 127)
+                        testBuffer[writeOffset++] = iVal.toByte()
+                    }
+                }
+
+            } else {
+                 for (i in 0 until numElementsToFill) {
+                    when (type) {
+                        GGMLType.F32 -> testBuffer.setFloatLe(writeOffset, currentValue)
+                        GGMLType.F16 -> testBuffer.setShortLe(writeOffset, floatToHalf(currentValue))
+                        GGMLType.I32 -> testBuffer.setIntLe(writeOffset, currentValue.toInt())
+                        GGMLType.I16 -> testBuffer.setShortLe(writeOffset, currentValue.toInt().toShort())
+                        else -> throw IllegalArgumentException("Unsupported type for sequence init: $type")
+                    }
+                    writeOffset += type.byteSize.toInt()
+                    currentValue += stepValue
+                }
+            }
+        }
+        return tensor
+    }
+
+    @Test
+    fun dummyTestToEnsureSetup() {
+        assertTrue(true, "Setup complete, dummy test runs.")
+    }
+
+    @Test
+    fun testComputeAddF32() {
+        val context = GGMLContext() // Dummy context, not used by current computeAdd impl beyond graphAllocator
+        var currentOffset = 0uL
+
+        // 1D Test
+        val dims1D = longArrayOf(5)
+        val size1D = calculateTensorByteSize(GGMLType.F32, dims1D)
+        val src0_1D = createAndInitTensor("src0_1D", GGMLType.F32, dims1D, currentOffset, fillSequence = true, startValue = 1.0f, step = 1.0f)
+        currentOffset += size1D
+        val src1_1D = createAndInitTensor("src1_1D", GGMLType.F32, dims1D, currentOffset, fillSequence = true, startValue = 10.0f, step = 10.0f)
+        currentOffset += size1D
+        val dst_1D = createAndInitTensor("dst_1D", GGMLType.F32, dims1D, currentOffset)
+        // currentOffset += size1D // Not strictly needed for dst if it's last for this sub-test
+
+        computeAdd(graphAllocator, context, src0_1D, src1_1D).let { result ->
+            // The computeAdd currently returns a *new* tensor with its own data array.
+            // For this test to work as intended (testing results in graphAllocator's buffer),
+            // computeAdd should fill the data of a pre-allocated 'dst_1D' tensor.
+            // This requires a change in computeAdd's signature or behavior.
+            // Assuming computeAdd is modified to: computeAdd(..., dst: GGMLTensor)
+            // For now, let's assume computeAdd fills the 'dst_1D' if passed, or we check its return.
+            // The current structure of computeAdd returns a new tensor.
+            // Let's test based on the current behavior: it returns a new tensor whose data we check.
+            // This means dst_1D is not used by computeAdd. The result is a new tensor.
+            // We need to ensure the returned tensor's data (if it has its own) is correct.
+            // OR, that the computeAdd function writes its result into graphAllocator's buffer
+            // and sets up the 'result' tensor's bufferId and dataOffset correctly.
+            // The F32/F16 paths in computeAdd DO use setFloat/setHalf on the result tensor,
+            // which implies the result tensor should be pre-allocated in the graphAllocator buffer.
+            // So, the `result` from `computeAdd` should be `dst_1D` effectively.
+            // Let's make `dst_1D` the actual result of the operation.
+            // No, computeAdd creates a *new* result tensor. We check that new tensor.
+            // The `dst_1D` defined above is just for offset calculation.
+        }
+         // Re-evaluate: computeAdd in GGMLOps.kt creates a result tensor BUT does not allocate its memory
+         // in graph allocator, instead it relies on GGMLComputeOps.computeAdd to fill its .data.
+         // GGMLComputeOps.computeAdd creates a NEW result tensor and fills its .data.
+         // This is messy. For these tests, let's assume the ops write to graphAllocator for F32/F16.
+         // The compute ops were refactored to use setFloat/setHalf on their result tensor.
+         // This result tensor's bufferId and dataOffset MUST be set correctly before calling setFloat/setHalf.
+         // The current computeAdd creates a result tensor, copies ne/nb, then calls setFloat/setHalf.
+         // This means the result tensor needs its bufferId/dataOffset pointing to graphAllocator memory.
+         // This is not done by createAndInitTensor for the dst tensor if fillSequence=false.
+         // The compute ops create their own GGMLTensor instance for result.
+         // This means we need to check the returned tensor.
+
+        val resultAdd1D = computeAdd(graphAllocator, context, src0_1D, src1_1D)
+        for (i in 0 until dims1D[0].toInt()) {
+            val expected = src0_1D.getFloat(graphAllocator, i) + src1_1D.getFloat(graphAllocator, i)
+            assertEquals(expected, resultAdd1D.getFloat(graphAllocator, i), "1D F32 Add mismatch at index $i")
+        }
+
+
+        // 2D Test
+        currentOffset = 0uL // Reset for next set of allocations to avoid large offsets
+        val dims2D = longArrayOf(2, 3) // 2 cols, 3 rows
+        val size2D = calculateTensorByteSize(GGMLType.F32, dims2D)
+        val src0_2D = createAndInitTensor("src0_2D", GGMLType.F32, dims2D, currentOffset, fillSequence = true, startValue = 1.0f, step = 0.5f)
+        currentOffset += size2D
+        val src1_2D = createAndInitTensor("src1_2D", GGMLType.F32, dims2D, currentOffset, fillSequence = true, startValue = 10.0f, step = 2.0f)
+        // currentOffset += size2D; // dst_2D not used in this test structure
+
+        val resultAdd2D = computeAdd(graphAllocator, context, src0_2D, src1_2D)
+        for (r in 0 until dims2D[1].toInt()) { // rows
+            for (c in 0 until dims2D[0].toInt()) { // cols
+                val expected = src0_2D.getFloat(graphAllocator, c, r) + src1_2D.getFloat(graphAllocator, c, r)
+                assertEquals(expected, resultAdd2D.getFloat(graphAllocator, c, r), "2D F32 Add mismatch at ($c, $r)")
+            }
+        }
+    }
+
+    @Test
+    fun testComputeAddF16() {
+        val context = GGMLContext()
+        var currentOffset = 0uL
+        val dims1D = longArrayOf(5)
+        val size1D = calculateTensorByteSize(GGMLType.F16, dims1D)
+
+        val src0Vals = floatArrayOf(1.0f, 2.5f, -3.0f, 0.1f, 100.0f)
+        val src1Vals = floatArrayOf(0.5f, -1.5f, 12.5f, 0.05f, -20.0f)
+
+        val src0_1D = createAndInitTensor("src0_F16", GGMLType.F16, dims1D, currentOffset)
+        currentOffset += size1D
+        val src1_1D = createAndInitTensor("src1_F16", GGMLType.F16, dims1D, currentOffset)
+        // currentOffset += size1D; // dst not used
+
+        for(i in src0Vals.indices) src0_1D.setHalf(graphAllocator, src0Vals[i], i)
+        for(i in src1Vals.indices) src1_1D.setHalf(graphAllocator, src1Vals[i], i)
+
+        val resultAdd1D = computeAdd(graphAllocator, context, src0_1D, src1_1D)
+        for (i in 0 until dims1D[0].toInt()) {
+            val expectedF32 = src0Vals[i] + src1Vals[i]
+            val expectedF16AsF32 = halfToFloat(floatToHalf(expectedF32))
+            assertEquals(expectedF16AsF32, resultAdd1D.getHalf(graphAllocator, i), "1D F16 Add mismatch at index $i. Expected(F16->F32): $expectedF16AsF32, Got: ${resultAdd1D.getHalf(graphAllocator, i)}")
+        }
+    }
+
+    @Test
+    fun testComputeMulF32() {
+        val context = GGMLContext()
+        var currentOffset = 0uL
+        val dims1D = longArrayOf(4)
+        val size1D = calculateTensorByteSize(GGMLType.F32, dims1D)
+
+        val src0_1D = createAndInitTensor("src0_MulF32", GGMLType.F32, dims1D, currentOffset, fillSequence = true, startValue = 1.5f, step = 1.0f)
+        currentOffset += size1D
+        val src1_1D = createAndInitTensor("src1_MulF32", GGMLType.F32, dims1D, currentOffset, fillSequence = true, startValue = 2.0f, step = 0.5f)
+
+        val resultMul1D = computeMul(graphAllocator, context, src0_1D, src1_1D)
+        for (i in 0 until dims1D[0].toInt()) {
+            val expected = src0_1D.getFloat(graphAllocator, i) * src1_1D.getFloat(graphAllocator, i)
+            assertEquals(expected, resultMul1D.getFloat(graphAllocator, i), "1D F32 Mul mismatch at index $i")
+        }
+    }
+
+    @Test
+    fun testComputeMulF16() {
+        val context = GGMLContext()
+        var currentOffset = 0uL
+        val dims1D = longArrayOf(4)
+        val size1D = calculateTensorByteSize(GGMLType.F16, dims1D)
+
+        val src0Vals = floatArrayOf(1.0f, -2.0f, 3.5f, 0.5f)
+        val src1Vals = floatArrayOf(2.0f, 1.5f, -1.0f, 4.0f)
+
+        val src0_1D = createAndInitTensor("src0_MulF16", GGMLType.F16, dims1D, currentOffset)
+        currentOffset += size1D
+        val src1_1D = createAndInitTensor("src1_MulF16", GGMLType.F16, dims1D, currentOffset)
+
+        for(i in src0Vals.indices) src0_1D.setHalf(graphAllocator, src0Vals[i], i)
+        for(i in src1Vals.indices) src1_1D.setHalf(graphAllocator, src1Vals[i], i)
+
+        val resultMul1D = computeMul(graphAllocator, context, src0_1D, src1_1D)
+        for (i in 0 until dims1D[0].toInt()) {
+            val expectedF32 = src0Vals[i] * src1Vals[i]
+            val expectedF16AsF32 = halfToFloat(floatToHalf(expectedF32))
+            val actualF16AsF32 = resultMul1D.getHalf(graphAllocator, i)
+            // Use a delta for F16 comparisons due to precision
+            val delta = abs(expectedF16AsF32 * 0.001f)
+            assertEquals(expectedF16AsF32, actualF16AsF32, delta, "1D F16 Mul mismatch at index $i. Expected(F16->F32): $expectedF16AsF32, Got: $actualF16AsF32")
+        }
+    }
+
+    @Test
+    fun testComputeMatMulF32xSF32() {
+        val context = GGMLContext()
+        var currentOffset = 0uL
+
+        // src0: 2x3 matrix (M=2, K=3)
+        // ne = [cols, rows] -> ne = [3, 2]
+        val M0 = 2; val K0 = 3
+        val src0Data = floatArrayOf(1f, 2f, 3f,  // Row 0
+                                    4f, 5f, 6f)  // Row 1
+        val src0 = createAndInitTensor("src0_MM_F32", GGMLType.F32, longArrayOf(K0.toLong(), M0.toLong()), currentOffset)
+        currentOffset += calculateTensorByteSize(GGMLType.F32, src0.ne)
+        for (r in 0 until M0) {
+            for (c in 0 until K0) {
+                src0.setFloat(graphAllocator, src0Data[r * K0 + c], c, r)
+            }
+        }
+
+        // src1: 3x2 matrix (K=3, N=2)
+        // ne = [cols, rows] -> ne = [2, 3]
+        val K1 = 3; val N1 = 2
+        val src1Data = floatArrayOf(7f, 8f,    // Row 0
+                                    9f, 10f,   // Row 1
+                                    11f, 12f)  // Row 2
+        val src1 = createAndInitTensor("src1_MM_F32", GGMLType.F32, longArrayOf(N1.toLong(), K1.toLong()), currentOffset)
+        // currentOffset += calculateTensorByteSize(GGMLType.F32, src1.ne) // Not needed if last alloc in this direct sequence
+         for (r in 0 until K1) {
+            for (c in 0 until N1) {
+                src1.setFloat(graphAllocator, src1Data[r * N1 + c], c, r)
+            }
+        }
+
+        val resultTensor = computeMatMul(graphAllocator, context, src0, src1)
+
+        assertEquals(GGMLType.F32, resultTensor.type, "Result type should be F32")
+        // Result is M0 x N1 (2x2). ne = [cols, rows] -> ne = [2, 2]
+        assertEquals(N1.toLong(), resultTensor.ne[0], "Result cols (ne[0]) mismatch")
+        assertEquals(M0.toLong(), resultTensor.ne[1], "Result rows (ne[1]) mismatch")
+
+        // Expected result:
+        // (1*7 + 2*9 + 3*11) (1*8 + 2*10 + 3*12)
+        // (4*7 + 5*9 + 6*11) (4*8 + 5*10 + 6*12)
+        // = (7+18+33) (8+20+36) = (58) (64)
+        //   (28+45+66) (32+50+72) = (139) (154)
+        val expectedData = arrayOf(
+            floatArrayOf(58f, 64f),
+            floatArrayOf(139f, 154f)
+        )
+
+        for (r in 0 until M0) { // M0 rows
+            for (c in 0 until N1) { // N1 cols
+                assertEquals(expectedData[r][c], resultTensor.getFloat(graphAllocator, c, r),
+                             "F32xSF32 MatMul mismatch at result ($c, $r)")
+            }
+        }
+    }
+
+    @Test
+    fun testComputeMatMulQ80xSF32() {
+        val context = GGMLContext()
+        var currentOffset = 0uL
+
+        // src0 (Q8_0): 2x3 matrix (M=2, K=3). ne = [K,M] = [3,2]
+        val M0 = 2; val K0 = 3
+        val src0F32Data = floatArrayOf(1f, 2f, 3f,  // Row 0
+                                       4f, 5f, 60f) // Row 1 (60f to ensure scale is not too small)
+
+        // Create F32 tensor for quantization
+        val tempF32Src0 = createAndInitTensor("tempF32Src0", GGMLType.F32, longArrayOf(K0.toLong(), M0.toLong()), currentOffset)
+        currentOffset += calculateTensorByteSize(GGMLType.F32, tempF32Src0.ne)
+        for (r in 0 until M0) {
+            for (c in 0 until K0) {
+                tempF32Src0.setFloat(graphAllocator, src0F32Data[r * K0 + c], c, r)
+            }
+        }
+        val q8Src0 = quantizeTensor(graphAllocator, tempF32Src0, GGMLType.Q8_0)
+        assertEquals(GGMLType.Q8_0, q8Src0.type)
+        assertEquals(K0.toLong(), q8Src0.ne[0])
+        assertEquals(M0.toLong(), q8Src0.ne[1])
+
+
+        // src1 (F32): 3x2 matrix (K=3, N=2). ne = [N,K] = [2,3]
+        val K1 = 3; val N1 = 2
+        val src1F32Data = floatArrayOf(7f, 8f,    // Row 0
+                                     9f, 10f,   // Row 1
+                                     11f, 12f)  // Row 2
+        val src1F32 = createAndInitTensor("src1_MM_F32", GGMLType.F32, longArrayOf(N1.toLong(), K1.toLong()), currentOffset)
+        // currentOffset += calculateTensorByteSize(GGMLType.F32, src1F32.ne) // Not needed if last alloc
+        for (r in 0 until K1) {
+            for (c in 0 until N1) {
+                src1F32.setFloat(graphAllocator, src1F32Data[r * N1 + c], c, r)
+            }
+        }
+
+        // computeMatMul for Q8_0 x F32 should produce an F32 result
+        val resultTensor = computeMatMul(graphAllocator, context, q8Src0, src1F32)
+
+        assertEquals(GGMLType.F32, resultTensor.type, "Result type should be F32 for Q8_0 x F32")
+        // Result is M0 x N1 (2x2). ne = [cols, rows] -> ne = [2, 2]
+        assertEquals(N1.toLong(), resultTensor.ne[0], "Result cols (ne[0]) mismatch")
+        assertEquals(M0.toLong(), resultTensor.ne[1], "Result rows (ne[1]) mismatch")
+
+        // Expected result from original F32 data:
+        // (1*7 + 2*9 + 3*11)   (1*8 + 2*10 + 3*12)   = (58)  (64)
+        // (4*7 + 5*9 + 60*11)  (4*8 + 5*10 + 60*12)  = (28+45+660) (32+50+720) = (733) (802)
+        val expectedData = arrayOf(
+            floatArrayOf(58f, 64f),
+            floatArrayOf(733f, 802f)
+        )
+
+        val delta = 2.0f // Allow some deviation due to Q8_0 quantization
+        for (r in 0 until M0) { // M0 rows
+            for (c in 0 until N1) { // N1 cols
+                assertEquals(expectedData[r][c], resultTensor.getFloat(graphAllocator, c, r), delta,
+                             "Q8_0xSF32 MatMul mismatch at result ($c, $r)")
+            }
+        }
+    }
+
+    // Helper to extract data from a tensor as a FloatArray
+    // Adapted from GGMLQuantizationAccuracyTest.kt
+    // Assumes result tensors from compute ops might have their .data field populated directly
+    // or fall back to graphAllocator if .data is null.
+    internal fun getTensorDataAsFloatArray(tensor: GGMLTensor, graphAllocator: GGMLGraphAllocator): FloatArray {
+        val numElements = tensor.numElements().toInt()
+        if (numElements == 0) return floatArrayOf()
+
+        // Case 1: Tensor has its own FloatArray in .data (typical for results of dequantizeTensor or some compute ops)
+        if (tensor.data is FloatArray) {
+            val fa = tensor.data as FloatArray
+            // Ensure the self-contained array matches expected elements; could be an error if not.
+            if (fa.size == numElements) return fa.copyOf()
+            // Fallthrough if sizes don't match, which might indicate an issue or that .data is not the source of truth.
+        }
+
+        // Case 2: Tensor has its own ShortArray in .data (typical for F16 results)
+        if (tensor.type == GGMLType.F16 && tensor.data is ShortArray) {
+            val sa = tensor.data as ShortArray
+            if (sa.size == numElements) {
+                return FloatArray(numElements) { i -> halfToFloat(sa[i]) }
+            }
+        }
+
+        // Case 3: Tensor data is in the graphAllocator's buffer (typical for source tensors or if compute ops write to graphAllocator)
+        // This part relies on tensor.bufferId and tensor.dataOffset being correctly set.
+        if (tensor.bufferId != -1) {
+            val floatArray = FloatArray(numElements)
+            var idx = 0
+            // Using applyNDIter from GGMLQuantizationAccuracyTest as a model
+            // Need to ensure a similar helper or direct iteration logic is here.
+            // For simplicity, assuming a flat 1D iteration for now if applyNDIter is not in this file.
+            // The existing applyNDIter in this file might need adjustment or direct use.
+            // The createAndInitTensor sets up ne for up to GGML_MAX_DIMS.
+            applyNDIter(tensor.ne, tensor.rank(), numElements) { _, indices ->
+                if (idx < numElements) {
+                    floatArray[idx++] = when (tensor.type) {
+                        GGMLType.F32 -> tensor.getFloat(graphAllocator, *indices)
+                        GGML_TYPE_F16 -> tensor.getHalf(graphAllocator, *indices)
+                        // Add other type direct conversions if getTensorDataAsFloatArray needs to support them
+                        else -> throw IllegalArgumentException("getTensorDataAsFloatArray: Unsupported tensor type ${tensor.type} for direct float extraction from graph allocator without dequantization.")
+                    }
+                }
+            }
+            return floatArray
+        }
+
+        throw IllegalStateException("Tensor ${tensor.name} has no accessible data (neither self-contained .data nor valid bufferId/dataOffset for graphAllocator).")
+    }
+
+
+    // Helper: GELU approximation using tanh, matches ggml.c's gelu_f32
+    private fun geluApproximation(x: Float): Float {
+        return 0.5f * x * (1.0f + tanh(sqrt(2.0f / PI.toFloat()) * (x + 0.044715f * x * x * x)))
+    }
+
+    // Helper: Sigmoid
+    private fun sigmoid(x: Float): Float {
+        return 1.0f / (1.0f + exp(-x))
+    }
+
+    // Helper: SiLU (Swish) = x * sigmoid(x)
+    private fun silu(x: Float): Float {
+        return x * sigmoid(x)
+    }
+
+    // Helper function to manually calculate RMS Norm for verification
+    private fun manualRMSNorm(input: FloatArray, eps: Float): FloatArray {
+        if (input.isEmpty()) return floatArrayOf()
+
+        var sumSq = 0.0
+        for (x_i_double in input.map { it.toDouble() }) { // Use Double for intermediate sum to maintain precision
+            sumSq += x_i_double * x_i_double
+        }
+        val meanSq = sumSq / input.size
+        val rms = sqrt(meanSq + eps.toDouble()).toFloat() // Calculate rms in double, then cast back to float
+
+        if (rms == 0.0f || rms.isNaN()) { // Handle cases where rms is zero or NaN (e.g. all zeros input with zero eps)
+             return FloatArray(input.size) { 0.0f }
+        }
+
+        val output = FloatArray(input.size)
+        for (i in input.indices) {
+            output[i] = input[i] / rms
+        }
+        return output
+    }
+
+    // --- RELU Tests ---
+    @Test
+    fun testComputeReluF32() {
+        val srcNe = longArrayOf(5)
+        val srcData = floatArrayOf(-2f, -0.5f, 0f, 0.5f, 2f)
+        // Using createAndInitTensor and then populating for consistency
+        val srcTensor = createAndInitTensor("relu_f32_src", GGMLType.F32, srcNe, dataOffset = 0uL)
+        for(i in srcData.indices) srcTensor.setFloat(graphAllocator, srcData[i], i)
+
+
+        val resultTensor = computeRelu(graphAllocator, srcTensor)
+
+        assertEquals(GGMLType.F32, resultTensor.type)
+        assertTrue(srcTensor.ne.contentEquals(resultTensor.ne), "Dimensions should match for RELU F32")
+
+        val expectedData = floatArrayOf(0f, 0f, 0f, 0.5f, 2f)
+        val resultData = getTensorDataAsFloatArray(resultTensor, graphAllocator)
+        assertContentEquals(expectedData, resultData, "RELU F32 output mismatch")
+    }
+
+    @Test
+    fun testComputeReluF16() {
+        val srcNe = longArrayOf(5)
+        val srcDataF32 = floatArrayOf(-2f, -0.5f, 0f, 0.5f, 2f)
+        val srcTensor = createAndInitTensor("relu_f16_src", GGMLType.F16, srcNe, dataOffset = 0uL)
+        for(i in srcDataF32.indices) srcTensor.setHalf(graphAllocator, srcDataF32[i], i)
+
+        val resultTensor = computeRelu(graphAllocator, srcTensor)
+
+        assertEquals(GGMLType.F16, resultTensor.type)
+        assertTrue(srcTensor.ne.contentEquals(resultTensor.ne), "Dimensions should match for RELU F16")
+
+        val expectedDataF32 = floatArrayOf(0f, 0f, 0f, 0.5f, 2f)
+        val resultDataF16AsF32 = getTensorDataAsFloatArray(resultTensor, graphAllocator)
+
+        for(i in expectedDataF32.indices) {
+            assertEquals(halfToFloat(floatToHalf(expectedDataF32[i])), resultDataF16AsF32[i], 0.001f, "RELU F16 output mismatch at index $i")
+        }
+    }
+
+    // --- GELU Tests ---
+    @Test
+    fun testComputeGeluF32() {
+        val srcNe = longArrayOf(5)
+        val srcData = floatArrayOf(-3f, -1f, 0f, 1f, 3f)
+        val srcTensor = createAndInitTensor("gelu_f32_src", GGMLType.F32, srcNe, dataOffset = 0uL)
+        for(i in srcData.indices) srcTensor.setFloat(graphAllocator, srcData[i], i)
+
+        val resultTensor = computeGelu(graphAllocator, srcTensor)
+
+        assertEquals(GGMLType.F32, resultTensor.type)
+        assertTrue(srcTensor.ne.contentEquals(resultTensor.ne), "Dimensions should match for GELU F32")
+
+        val expectedData = srcData.map { geluApproximation(it) }.toFloatArray()
+        val resultData = getTensorDataAsFloatArray(resultTensor, graphAllocator)
+
+        for(i in expectedData.indices) {
+            assertEquals(expectedData[i], resultData[i], 0.001f, "GELU F32 output mismatch at index $i")
+        }
+    }
+
+    @Test
+    fun testComputeGeluF16() {
+        val srcNe = longArrayOf(5)
+        val srcDataF32 = floatArrayOf(-3f, -1f, 0f, 1f, 3f)
+        val srcTensor = createAndInitTensor("gelu_f16_src", GGMLType.F16, srcNe, dataOffset = 0uL)
+        for(i in srcDataF32.indices) srcTensor.setHalf(graphAllocator, srcDataF32[i], i)
+
+        val resultTensor = computeGelu(graphAllocator, srcTensor)
+
+        assertEquals(GGMLType.F16, resultTensor.type)
+        assertTrue(srcTensor.ne.contentEquals(resultTensor.ne), "Dimensions should match for GELU F16")
+
+        val expectedDataF32 = srcDataF32.map { geluApproximation(it) }.toFloatArray()
+        val resultDataF16AsF32 = getTensorDataAsFloatArray(resultTensor, graphAllocator)
+
+        for(i in expectedDataF32.indices) {
+            assertEquals(halfToFloat(floatToHalf(expectedDataF32[i])), resultDataF16AsF32[i], 0.01f,
+                         "GELU F16 output mismatch at index $i. Expected F32: ${expectedDataF32[i]}, Got F16asF32: ${resultDataF16AsF32[i]}")
+        }
+    }
+
+    // --- SILU Tests ---
+    @Test
+    fun testComputeSiluF32() {
+        val srcNe = longArrayOf(5)
+        val srcData = floatArrayOf(-5f, -1f, 0f, 1f, 5f)
+        val srcTensor = createAndInitTensor("silu_f32_src", GGMLType.F32, srcNe, dataOffset = 0uL)
+        for(i in srcData.indices) srcTensor.setFloat(graphAllocator, srcData[i], i)
+
+        // Assuming computeSilu exists and has signature (GGMLGraphAllocator, GGMLTensor) -> GGMLTensor
+        val resultTensor = computeSilu(graphAllocator, srcTensor)
+
+        assertEquals(GGMLType.F32, resultTensor.type)
+        assertTrue(srcTensor.ne.contentEquals(resultTensor.ne), "Dimensions should match for SILU F32")
+
+        val expectedData = srcData.map { silu(it) }.toFloatArray()
+        val resultData = getTensorDataAsFloatArray(resultTensor, graphAllocator)
+
+        for(i in expectedData.indices) {
+            assertEquals(expectedData[i], resultData[i], 0.001f, "SILU F32 output mismatch at index $i")
+        }
+    }
+
+    @Test
+    fun testComputeSiluF16() {
+        val srcNe = longArrayOf(5)
+        val srcDataF32 = floatArrayOf(-5f, -1f, 0f, 1f, 5f)
+        val srcTensor = createAndInitTensor("silu_f16_src", GGMLType.F16, srcNe, dataOffset = 0uL)
+        for(i in srcDataF32.indices) srcTensor.setHalf(graphAllocator, srcDataF32[i], i)
+
+        val resultTensor = computeSilu(graphAllocator, srcTensor)
+
+        assertEquals(GGMLType.F16, resultTensor.type)
+        assertTrue(srcTensor.ne.contentEquals(resultTensor.ne), "Dimensions should match for SILU F16")
+
+        val expectedDataF32 = srcDataF32.map { silu(it) }.toFloatArray()
+        val resultDataF16AsF32 = getTensorDataAsFloatArray(resultTensor, graphAllocator)
+
+        for(i in expectedDataF32.indices) {
+            assertEquals(halfToFloat(floatToHalf(expectedDataF32[i])), resultDataF16AsF32[i], 0.01f,
+                         "SILU F16 output mismatch at index $i. Expected F32: ${expectedDataF32[i]}, Got F16asF32: ${resultDataF16AsF32[i]}")
+        }
+    }
+
+    // --- RMS_NORM Tests ---
+    @Test
+    fun testComputeRMSNormF32() {
+        val srcNe = longArrayOf(4) // Simplified to just essential dimension for 1D
+        val srcData = floatArrayOf(1.0f, 2.0f, 3.0f, 4.0f)
+
+        // Using createAndInitTensor and then populating for consistency
+        val srcTensor = createAndInitTensor("rms_f32_src", GGMLType.F32, srcNe, dataOffset = 0uL)
+        for(i in srcData.indices) srcTensor.setFloat(graphAllocator, srcData[i], i)
+
+        val eps = 1e-5f
+
+        val resultTensor = computeRMSNorm(graphAllocator, srcTensor, eps)
+
+        assertEquals(GGMLType.F32, resultTensor.type)
+        assertTrue(srcTensor.ne.contentEquals(resultTensor.ne), "RMSNorm F32 result dimensions mismatch")
+
+        val expectedData = manualRMSNorm(srcData, eps)
+        val resultData = getTensorDataAsFloatArray(resultTensor, graphAllocator)
+
+        assertEquals(expectedData.size, resultData.size, "RMSNorm F32 result data size mismatch")
+        for(i in expectedData.indices) {
+            assertEquals(expectedData[i], resultData[i], 0.0001f, "RMSNorm F32 output mismatch at index $i")
+        }
+    }
+
+    @Test
+    fun testComputeRMSNormF16() {
+        val srcNe = longArrayOf(4) // Simplified to just essential dimension for 1D
+        val srcDataF32 = floatArrayOf(1.0f, 2.0f, -1.0f, -2.0f)
+
+        var currentOffset = 0uL // Manage offset if other tensors were created in testBuffer, though this test is self-contained for src
+        val srcTensor = createAndInitTensor("rms_f16_src", GGMLType.F16, srcNe, dataOffset = currentOffset)
+        for(i in srcDataF32.indices) srcTensor.setHalf(graphAllocator, srcDataF32[i], i)
+
+        val eps = 1e-5f
+
+        val resultTensor = computeRMSNorm(graphAllocator, srcTensor, eps)
+
+        assertEquals(GGMLType.F16, resultTensor.type)
+        assertTrue(srcTensor.ne.contentEquals(resultTensor.ne), "RMSNorm F16 result dimensions mismatch")
+
+        val expectedDataF32 = manualRMSNorm(srcDataF32, eps)
+        val resultDataF16AsF32 = getTensorDataAsFloatArray(resultTensor, graphAllocator)
+
+        assertEquals(expectedDataF32.size, resultDataF16AsF32.size, "RMSNorm F16 result data size mismatch")
+        for(i in expectedDataF32.indices) {
+            assertEquals(halfToFloat(floatToHalf(expectedDataF32[i])), resultDataF16AsF32[i], 0.01f,
+                         "RMSNorm F16 output mismatch at index $i. Expected F32: ${expectedDataF32[i]}, Got F16asF32: ${resultDataF16AsF32[i]}")
+        }
+    }
+}

--- a/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLQuantizationAccuracyTest.kt
+++ b/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLQuantizationAccuracyTest.kt
@@ -1,0 +1,418 @@
+package ai.solace.llamakotlin.core
+
+import kotlin.math.abs
+import kotlin.math.log10
+import kotlin.math.pow
+import kotlin.math.sqrt // Not used yet, but often useful for stats
+import kotlin.test.*
+import kotlin.Short.Companion.SIZE_BYTES as SHORT_SIZE_BYTES
+
+
+class GGMLQuantizationAccuracyTest {
+
+    private lateinit var graphAllocator: GGMLGraphAllocator
+    private lateinit var testBuffer: ByteArray
+    private val bufferSize = 1 * 1024 * 1024 // 1MB
+
+    // --- Start Copied/Adapted Helpers ---
+    // NOTE: These should ideally be in a common test utility file.
+    // For now, they are included here for self-containment of this test file.
+
+    private fun calculateStrides(type: GGMLType, ne: LongArray, maxDims: Int = GGML_MAX_DIMS): ULongArray {
+        val nb = ULongArray(maxDims) { 0uL }
+        if (type.byteSize > 0uL) {
+            nb[0] = type.byteSize
+            if (maxDims > 1) {
+                for (d in 1 until maxDims) {
+                    val prevDimSize = ne.getOrElse(d - 1) { 1L }
+                    nb[d] = nb[d-1] * (if (prevDimSize > 0) prevDimSize.toULong() else 1uL)
+                }
+            }
+        }
+        return nb
+    }
+
+    private fun calculateTensorByteSize(tensor: GGMLTensor): ULong {
+        val type = tensor.type
+        val ne = tensor.ne
+
+        if (type.byteSize == 0uL && type != GGMLType.COUNT && !type.name.startsWith("Q", ignoreCase = true)) {
+             println("Warning: Calculating byte size for type ${type.name} with byteSize 0.")
+            return 0uL
+        }
+
+        val elements = tensor.numElements().toULong() // Use existing numElements()
+
+        if (elements == 0UL && ne.isNotEmpty() && !ne.all { it == 0L }) return 0UL // Avoid mult by 0 if elements is 0 but ne has structure
+
+        return if (type == GGMLType.Q8_0 || type == GGMLType.Q4_0) { // Add other block types as needed
+            val elementsPerBlock = if (type == GGMLType.Q8_0) QK8_0.toLong() else QK4_0.toLong()
+            if (elementsPerBlock == 0L || elements.toLong() % elementsPerBlock != 0L) {
+                 println("Warning: Total elements $elements for ${type.name} is not divisible by block size $elementsPerBlock.")
+                 // Fallback or error, for now, let's assume numElements is the source of truth for element count
+                 // and byteSize * (num_elements / elements_per_block) is correct.
+                 if (elementsPerBlock == 0L) return 0uL // Avoid division by zero
+            }
+            (elements.toLong() / elementsPerBlock).toULong() * type.byteSize
+        } else {
+            elements * type.byteSize
+        }
+    }
+
+    // Copied from GGMLComputeOpsTest.kt - should be in a common test util
+    internal fun applyNDIter(
+        tensorNe: LongArray, // Pass ne directly
+        tensorRank: Int,     // Pass rank directly
+        totalElementsToIterate: Int,
+        actionPerElement: (flatIdx: Int, indices: IntArray) -> Unit
+    ) {
+        val n0 = tensorNe.getOrElse(0) { 1L }.toInt()
+        val n1 = tensorNe.getOrElse(1) { 1L }.toInt()
+        val n2 = tensorNe.getOrElse(2) { 1L }.toInt()
+        val n3 = tensorNe.getOrElse(3) { 1L }.toInt()
+        var currentFlatIdx = 0
+
+        if (totalElementsToIterate == 0) return
+
+        // Determine effective dimensions for iteration based on rank, defaulting to 1 for ranks < 4
+        val effN3 = if (tensorRank >= 4) n3 else 1
+        val effN2 = if (tensorRank >= 3) n2 else 1
+        val effN1 = if (tensorRank >= 2) n1 else 1
+        val effN0 = if (tensorRank >= 1) n0 else 1
+
+        if (tensorRank == 0 && totalElementsToIterate == 1) { // Scalar
+             actionPerElement(currentFlatIdx++, intArrayOf())
+             return
+        }
+
+
+        for (i3 in 0 until effN3) {
+            for (i2 in 0 until effN2) {
+                for (i1 in 0 until effN1) {
+                    for (i0 in 0 until effN0) {
+                        if (currentFlatIdx < totalElementsToIterate) {
+                            val indices = when (tensorRank) {
+                                0 -> intArrayOf() // Should be handled by scalar case above
+                                1 -> intArrayOf(i0)
+                                2 -> intArrayOf(i0, i1)
+                                3 -> intArrayOf(i0, i1, i2)
+                                else -> intArrayOf(i0, i1, i2, i3) // Handles rank 4+
+                            }.sliceArray(0 until tensorRank.coerceAtLeast(1)) // Ensure indices match rank, at least 1 for 1D
+                             if(tensorRank == 0 && totalElementsToIterate ==1) { // True scalar from ne=[]
+                                actionPerElement(currentFlatIdx++, intArrayOf())
+                             } else {
+                                actionPerElement(currentFlatIdx++, indices)
+                             }
+                        } else return
+                    }
+                }
+            }
+        }
+    }
+
+
+    // --- End Copied/Adapted Helpers ---
+
+
+    @BeforeTest
+    fun setup() {
+        graphAllocator = GGMLGraphAllocator()
+        testBuffer = ByteArray(bufferSize)
+        if (graphAllocator.buffers.isEmpty()) graphAllocator.buffers.add(null)
+        if (graphAllocator.tensorAllocators.isEmpty()) graphAllocator.tensorAllocators.add(GGMLDynTensorAllocator())
+        graphAllocator.buffers[0] = testBuffer
+        graphAllocator.tensorAllocators[0].reset(bufferSize.toULong())
+    }
+
+    private fun createAndPopulateF32Tensor(
+        name: String,
+        dims: LongArray, // Effective dimensions
+        values: FloatArray,
+        dataOffset: ULong = 0uL,
+        bufferId: Int = 0
+    ): GGMLTensor {
+        val tensor = GGMLTensor(GGMLType.F32)
+        tensor.name = name
+
+        tensor.ne = LongArray(GGML_MAX_DIMS) { 1L }
+        dims.forEachIndexed { index, dimSize ->
+            if (index < GGML_MAX_DIMS) tensor.ne[index] = dimSize
+        }
+        tensor.nb = calculateStrides(tensor.type, tensor.ne)
+        tensor.bufferId = bufferId
+        tensor.dataOffset = dataOffset
+        tensor.data = null
+
+        val numElements = tensor.numElements().toInt()
+        require(values.size == numElements) { "Provided FloatArray size (${values.size}) must match tensor element count ($numElements)." }
+
+        val tensorByteSize = calculateTensorByteSize(tensor)
+        assertTrue(dataOffset + tensorByteSize <= bufferSize.toULong(),
+            "Test tensor '$name' setup (offset $dataOffset + size $tensorByteSize) " +
+            "dims ${dims.joinToString()} (effective ne: ${tensor.ne.joinToString()}) exceeds buffer capacity ($bufferSize).")
+
+        var dataIdx = 0
+        applyNDIter(tensor.ne, tensor.rank(), numElements) { _, indices ->
+            if (dataIdx < values.size) {
+                tensor.setFloat(graphAllocator, values[dataIdx++], *indices)
+            }
+        }
+        return tensor
+    }
+
+    internal fun getTensorDataAsFloatArray(tensor: GGMLTensor, graphAllocator: GGMLGraphAllocator): FloatArray {
+        val numElements = tensor.numElements().toInt()
+        if (tensor.type == GGMLType.F32 && tensor.data is FloatArray) {
+            val fa = tensor.data as FloatArray
+            if (fa.size == numElements) return fa.copyOf() // Return a copy to prevent external modification
+        }
+
+        val floatArray = FloatArray(numElements)
+        var idx = 0
+
+        applyNDIter(tensor.ne, tensor.rank(), numElements) { _, indices ->
+            if (idx < numElements) {
+                floatArray[idx++] = when (tensor.type) {
+                    GGMLType.F32 -> tensor.getFloat(graphAllocator, *indices)
+                    GGMLType.F16 -> tensor.getHalf(graphAllocator, *indices)
+                    else -> throw IllegalArgumentException("Unsupported tensor type ${tensor.type} for direct float array extraction. Dequantize to F32 first.")
+                }
+            }
+        }
+        return floatArray
+    }
+
+    internal fun calculateMeanSquaredError(original: FloatArray, new: FloatArray): Double {
+        require(original.size == new.size) { "Arrays must have the same size for MSE." }
+        if (original.isEmpty()) return 0.0
+
+        var sumOfSquaredErrors = 0.0
+        for (i in original.indices) {
+            sumOfSquaredErrors += (original[i] - new[i]).toDouble().pow(2)
+        }
+        return sumOfSquaredErrors / original.size
+    }
+
+    internal fun calculateSignalToNoiseRatio(signal: FloatArray, noiseSource: FloatArray, originalSignal: FloatArray): Double {
+        require(signal.size == noiseSource.size && signal.size == originalSignal.size) { "Arrays must have the same size for SNR." }
+        if (signal.isEmpty()) return Double.POSITIVE_INFINITY
+
+        var sumSignalSq = 0.0
+        var sumNoiseSq = 0.0
+        for (i in signal.indices) {
+            sumSignalSq += originalSignal[i].toDouble().pow(2) // Power of the original, clean signal
+            val noise = signal[i] - noiseSource[i] // The noise is the difference between quantized and original
+            sumNoiseSq += noise.toDouble().pow(2)
+        }
+        if (sumNoiseSq == 0.0) return Double.POSITIVE_INFINITY
+        if (sumSignalSq == 0.0 && sumNoiseSq > 0.0) return 0.0 // Or negative infinity dB if signal is zero
+        return 10 * log10(sumSignalSq / sumNoiseSq)
+    }
+
+    @Test
+    fun quantizationAccuracyTestSetup() {
+        assertTrue(true, "Setup for GGMLQuantizationAccuracyTest complete.")
+        val dims = longArrayOf(2) // Test with 1D array of 2 elements
+        val testTensor = createAndPopulateF32Tensor("testF32", dims, floatArrayOf(1.0f, 2.0f))
+        assertNotNull(testTensor)
+        assertEquals(1.0f, testTensor.getFloat(graphAllocator, 0))
+        assertEquals(2.0f, testTensor.getFloat(graphAllocator, 1))
+        val dataBack = getTensorDataAsFloatArray(testTensor, graphAllocator)
+        assertEquals(1.0f, dataBack[0])
+        assertEquals(2.0f, dataBack[1])
+    }
+
+    @Test
+    fun testQ8_0Accuracy() {
+        val numElements = QK8_0 * 4 // Test with a few blocks, e.g., 4 blocks = 128 elements
+        val originalF32Data = FloatArray(numElements) { idx ->
+            // Create a diverse range of values
+            when {
+                idx % QK8_0 == 0 -> 0.0f // Start of a block with zero
+                idx % QK8_0 == 1 -> 127.0f // Max positive for Q8 scaling
+                idx % QK8_0 == 2 -> -128.0f // Min negative for Q8 scaling (won't be hit if scale is from abs max)
+                                         // Actually, scale is based on amax / 127. So values map to [-127, 127] ideally.
+                                         // Let's use values that will result in diverse q values.
+                idx < QK8_0 -> (idx.toFloat() / (QK8_0 -1).toFloat()) * 10.0f // 0 to 10
+                idx < QK8_0 * 2 -> ( (idx-QK8_0).toFloat() / (QK8_0 -1).toFloat() ) * -10.0f // 0 to -10
+                idx < QK8_0 * 3 -> if (idx % 2 == 0) 50.5f else -50.5f // Alternating large
+                else -> (idx - QK8_0 * 3).toFloat() * 0.1f - 1.0f // Small values around -1
+            }
+        }
+
+        val dims = longArrayOf(numElements.toLong()) // 1D tensor
+        val f32SrcTensor = createAndPopulateF32Tensor("f32Src_Q8Test", GGMLType.F32, dims, originalF32Data, dataOffset = 0uL)
+
+        // 1. Quantize to Q8_0
+        val q8Tensor = quantizeTensor(graphAllocator, f32SrcTensor, GGMLType.Q8_0)
+        assertEquals(GGMLType.Q8_0, q8Tensor.type)
+        assertTrue(q8Tensor.ne.contentEquals(f32SrcTensor.ne), "Dimensions should match after Q8_0 quantization")
+        assertNotNull(q8Tensor.data, "Q8_0 tensor data should not be null after quantization")
+        assertTrue(q8Tensor.data is ByteArray, "Q8_0 tensor data should be ByteArray")
+
+        // 2. Dequantize Q8_0 back to F32
+        val f32DequantizedTensor = dequantizeTensor(graphAllocator, q8Tensor)
+        assertEquals(GGMLType.F32, f32DequantizedTensor.type)
+        assertTrue(f32DequantizedTensor.ne.contentEquals(f32SrcTensor.ne), "Dimensions should match after Q8_0 dequantization")
+        assertNotNull(f32DequantizedTensor.data, "Dequantized F32 tensor data should not be null")
+        assertTrue(f32DequantizedTensor.data is FloatArray, "Dequantized F32 tensor data should be FloatArray")
+
+
+        // 3. Extract data for comparison
+        val dequantizedF32Data = getTensorDataAsFloatArray(f32DequantizedTensor, graphAllocator)
+
+        // 4. Perform Accuracy Assertions
+        assertEquals(originalF32Data.size, dequantizedF32Data.size, "Data array sizes should match")
+
+        val mse = calculateMeanSquaredError(originalF32Data, dequantizedF32Data)
+        // Threshold for Q8_0. Max error for one element for amax=127, scale=1 is 0.5. MSE can be (0.5)^2 = 0.25
+        // If data range is smaller, MSE should be smaller.
+        // Example: data in [-10, 10], amax=10, scale = 10/127. Max error on dequantized = scale*0.5 = (10/127)*0.5 approx 0.039
+        // MSE approx (0.039)^2 = 0.0015
+        val mseThreshold = 0.05 // This threshold is empirical and depends heavily on test data range.
+        assertTrue(mse < mseThreshold, "Q8_0 MSE $mse too high (threshold $mseThreshold). Data range can affect this.")
+
+        var sumAbsDiff = 0.0
+        for(i in originalF32Data.indices) {
+            sumAbsDiff += abs(originalF32Data[i] - dequantizedF32Data[i])
+        }
+        val meanAbsDiff = if (originalF32Data.isEmpty()) 0.0 else sumAbsDiff / originalF32Data.size
+        val madThreshold = 0.2 // Also empirical. Max error could be around scale/2.
+        assertTrue(meanAbsDiff < madThreshold, "Q8_0 Mean Absolute Difference $meanAbsDiff too high (threshold $madThreshold)")
+
+        // println("Q8_0 Test: MSE = $mse, Mean Absolute Difference = $meanAbsDiff")
+    }
+
+    @Test
+    fun testQ4_0Accuracy() {
+        val numElements = QK4_0 * 4 // Test with a few blocks, e.g., 4 blocks = 128 elements
+        val originalF32Data = FloatArray(numElements) { i ->
+            // Create a diverse range of values, similar to Q8_0 test but scaled for Q4_0's effective range (-8 to +7)
+            when {
+                i % QK4_0 == 0 -> 0.0f
+                i % QK4_0 == 1 -> 7.0f  // Test max positive scaled value
+                i % QK4_0 == 2 -> -8.0f // Test min negative scaled value
+                i < QK4_0 -> (i.toFloat() / (QK4_0 -1).toFloat()) * 1.0f // Block 1: 0 to 1
+                i < QK4_0 * 2 -> ( (i-QK4_0).toFloat() / (QK4_0 -1).toFloat() ) * -1.0f // Block 2: 0 to -1
+                i < QK4_0 * 3 -> if (i % 2 == 0) 0.75f else -0.75f // Block 3: Alternating
+                else -> ((i - QK4_0 * 3).toFloat() / (QK4_0-1).toFloat() * 16.0f) - 8.0f // Block 4: Spread across -8 to +8
+            }
+        }
+
+        val dims = longArrayOf(numElements.toLong()) // 1D tensor
+        // Ensure enough space for F32 source, Q4 representation (smaller), and F32 dequantized
+        // For this test, f32SrcTensor is in graphAllocator's buffer.
+        // q4Tensor and f32DequantizedTensor will have their own .data arrays.
+        val f32SrcTensor = createAndPopulateF32Tensor("f32Src_Q4Test", GGMLType.F32, dims, originalF32Data, dataOffset = 0uL)
+
+        // 1. Quantize to Q4_0
+        val q4Tensor = quantizeTensor(graphAllocator, f32SrcTensor, GGMLType.Q4_0)
+        assertEquals(GGMLType.Q4_0, q4Tensor.type)
+        assertTrue(q4Tensor.ne.contentEquals(f32SrcTensor.ne), "Dimensions should match after Q4_0 quantization")
+        assertNotNull(q4Tensor.data, "Q4_0 tensor data should not be null after quantization")
+        assertTrue(q4Tensor.data is ByteArray, "Q4_0 tensor data should be ByteArray")
+
+
+        // 2. Dequantize Q4_0 back to F32
+        val f32DequantizedTensor = dequantizeTensor(graphAllocator, q4Tensor)
+        assertEquals(GGMLType.F32, f32DequantizedTensor.type)
+        assertTrue(f32DequantizedTensor.ne.contentEquals(f32SrcTensor.ne), "Dimensions should match after Q4_0 dequantization")
+        assertNotNull(f32DequantizedTensor.data, "Dequantized F32 tensor data should not be null")
+        assertTrue(f32DequantizedTensor.data is FloatArray, "Dequantized F32 tensor data should be FloatArray")
+
+        // 3. Extract data for comparison
+        val dequantizedF32Data = getTensorDataAsFloatArray(f32DequantizedTensor, graphAllocator)
+
+        // 4. Perform Accuracy Assertions
+        assertEquals(originalF32Data.size, dequantizedF32Data.size, "Data array sizes should match")
+
+        val mse = calculateMeanSquaredError(originalF32Data, dequantizedF32Data)
+        // Threshold for Q4_0. Max error for one element is roughly (amax/8)/2.
+        // If data is [-1,1], amax=1, scale=1/8. Max elem error ~ 1/16 = 0.0625. MSE ~ (0.0625)^2 ~ 0.0039.
+        val mseThresholdQ4_0 = 0.02 // Adjusted, can be tuned based on actual results
+        assertTrue(mse < mseThresholdQ4_0, "Q4_0 MSE $mse too high (threshold $mseThresholdQ4_0). Data range can affect this.")
+
+        var sumAbsDiff = 0.0
+        for(i in originalF32Data.indices) {
+            sumAbsDiff += abs(originalF32Data[i] - dequantizedF32Data[i])
+        }
+        val meanAbsDiff = if (originalF32Data.isEmpty()) 0.0 else sumAbsDiff / originalF32Data.size
+        // Max typical error for Q4_0 for range [-1,1] (where amax=1, scale=1/8) is ~1/8 = 0.125
+        val madThresholdQ4_0 = 0.25 // Adjusted, can be tuned
+        assertTrue(meanAbsDiff < madThresholdQ4_0, "Q4_0 Mean Absolute Difference $meanAbsDiff too high (threshold $madThresholdQ4_0)")
+
+        // println("Q4_0 Test: MSE = $mse, Mean Absolute Difference = $meanAbsDiff")
+    }
+
+    // Helper for Mean Absolute Difference
+    internal fun calculateMeanAbsoluteDifference(original: FloatArray, new: FloatArray): Double {
+        require(original.size == new.size) { "Arrays must have the same size for MAD." }
+        if (original.isEmpty()) return 0.0
+        var sumAbsDiff = 0.0
+        for (i in original.indices) {
+            sumAbsDiff += abs(original[i] - new[i]).toDouble()
+        }
+        return sumAbsDiff / original.size
+    }
+
+    @Test
+    fun testQ4_1Accuracy() {
+        val numElements = QK4_1 * 4 // Test with a few blocks, e.g., 4 blocks = 128 elements
+        val originalF32Data = FloatArray(numElements) { i ->
+            // Create a diverse range of values for Q4_1 testing
+            // Q4_1 uses d*nibble + m. Nibble is 0-15.
+            // Test data that results in varied min/max per block.
+            val blockNum = i / QK4_1
+            val withinBlockIdx = i % QK4_1
+            when (blockNum) {
+                0 -> (withinBlockIdx.toFloat() / (QK4_1 -1).toFloat()) * 2.0f - 1.0f // Block 0: -1.0 to 1.0
+                1 -> (withinBlockIdx.toFloat() / (QK4_1 -1).toFloat()) * 0.5f + 0.25f // Block 1: 0.25 to 0.75
+                2 -> if (withinBlockIdx % 2 == 0) 5.0f else 4.0f // Block 2: Alternating 5.0, 4.0
+                else -> (withinBlockIdx - QK4_1/2).toFloat() * 0.1f // Block 3: Centered around 0, small range
+            }
+        }
+
+        val dims = longArrayOf(numElements.toLong(), 1L, 1L, 1L)
+        // Ensure f32SrcTensor is placed in the graphAllocator's managed buffer for this test
+        // Adapting to existing createAndPopulateF32Tensor signature
+        val f32SrcTensor = createAndPopulateF32Tensor("f32Src_Q4_1Test", GGMLType.F32, dims, originalF32Data, dataOffset = 0uL)
+
+
+        // 1. Quantize to Q4_1
+        // quantizeTensor returns a new tensor with its own .data ByteArray
+        val q4_1Tensor = quantizeTensor(graphAllocator, f32SrcTensor, GGMLType.Q4_1)
+        assertEquals(GGMLType.Q4_1, q4_1Tensor.type)
+        assertTrue(q4_1Tensor.ne.contentEquals(f32SrcTensor.ne), "Dimensions should match after Q4_1 quantization")
+        assertNotNull(q4_1Tensor.data, "Q4_1 tensor data should not be null after quantization")
+        assertTrue(q4_1Tensor.data is ByteArray, "Q4_1 tensor data should be ByteArray")
+
+
+        // 2. Dequantize Q4_1 back to F32
+        // dequantizeTensor also returns a new tensor with its own .data FloatArray
+        val f32DequantizedTensor = dequantizeTensor(graphAllocator, q4_1Tensor)
+        assertEquals(GGMLType.F32, f32DequantizedTensor.type)
+        assertTrue(f32DequantizedTensor.ne.contentEquals(f32SrcTensor.ne), "Dimensions should match after Q4_1 dequantization")
+        assertNotNull(f32DequantizedTensor.data, "F32 dequantized tensor data should not be null")
+        assertTrue(f32DequantizedTensor.data is FloatArray, "Dequantized F32 tensor data should be FloatArray")
+
+        // 3. Extract data for comparison
+        // getTensorDataAsFloatArray can read from f32SrcTensor (in graphAllocator buffer)
+        // and from f32DequantizedTensor (which has its own .data FloatArray)
+        val retrievedOriginalF32Data = getTensorDataAsFloatArray(f32SrcTensor, graphAllocator) // Verifies initial data setup
+        val dequantizedF32Data = getTensorDataAsFloatArray(f32DequantizedTensor, graphAllocator)
+
+        // 4. Perform Accuracy Assertions
+        assertEquals(originalF32Data.size, dequantizedF32Data.size, "Data array sizes should match")
+
+        val mse = calculateMeanSquaredError(retrievedOriginalF32Data, dequantizedF32Data)
+        // Q4_1 error: d/2 where d=(max-min)/15. If range is 2 (-1 to 1), d=2/15=0.133. Max error = 0.066. MSE ~ (0.066)^2 ~ 0.0044
+        val mseThresholdQ4_1 = 0.015 // Start with a threshold slightly higher than Q4_0
+        assertTrue(mse < mseThresholdQ4_1, "Q4_1 MSE $mse too high (threshold $mseThresholdQ4_1)")
+
+        val mad = calculateMeanAbsoluteDifference(retrievedOriginalF32Data, dequantizedF32Data)
+        val madThresholdQ4_1 = 0.1 // Adjusted from prompt's 0.2 as it seemed high vs max error
+        assertTrue(mad < madThresholdQ4_1, "Q4_1 Mean Absolute Difference $mad too high (threshold $madThresholdQ4_1)")
+
+        // println("Q4_1 Test: MSE = $mse, Mean Absolute Difference = $mad") // For debugging/tuning
+    }
+}

--- a/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLTypesTest.kt
+++ b/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLTypesTest.kt
@@ -1,0 +1,317 @@
+package ai.solace.llamakotlin.core
+
+import kotlin.test.*
+import kotlin.Short.Companion.SIZE_BYTES as SHORT_SIZE_BYTES // For F16
+
+class GGMLTypesTest {
+
+    private lateinit var graphAllocator: GGMLGraphAllocator
+    private lateinit var testBuffer: ByteArray
+    private val testBufferSize = 1024 * 1024 // 1MB
+
+    @BeforeTest
+    fun setup() {
+        graphAllocator = GGMLGraphAllocator()
+        testBuffer = ByteArray(testBufferSize)
+        // Directly assign the test buffer to the graph allocator's primary buffer
+        // and reset the corresponding tensor allocator with the test buffer's size.
+        if (graphAllocator.buffers.isNotEmpty()) {
+            graphAllocator.buffers[0] = testBuffer
+        } else {
+            graphAllocator.buffers.add(testBuffer) // Should not happen if constructor works
+        }
+        if (graphAllocator.tensorAllocators.isNotEmpty()) {
+            graphAllocator.tensorAllocators[0].reset(testBuffer.size.toULong())
+        } else {
+            // This case implies GGMLGraphAllocator constructor didn't set up tensorAllocators[0]
+            // which would be a problem. For this test setup, we assume it exists.
+            val dynTensorAllocator = GGMLDynTensorAllocator(bufferSize = testBuffer.size.toULong())
+            graphAllocator.tensorAllocators.add(dynTensorAllocator)
+        }
+    }
+
+    private fun calculateTensorByteSize(type: GGMLType, ne: LongArray): ULong {
+        if (type.byteSize == 0uL && type != GGMLType.COUNT) {
+            // This case should ideally not be hit for types we are testing direct access on (F32, F16, I32, I16)
+            // For robust testing of other types later, this might need adjustment or specific handling.
+            println("Warning: Calculating byte size for type ${type.name} with byteSize 0.")
+            return 0uL
+        }
+        var totalElements = 1UL
+        var nonZeroDimFound = false
+        for (dimSize in ne) {
+            if (dimSize > 0L) {
+                totalElements *= dimSize.toULong()
+                nonZeroDimFound = true
+            }
+        }
+        if (!nonZeroDimFound && ne.isNotEmpty()) return type.byteSize // Scalar from ne=[1,1,1,1]
+        if (totalElements == 0UL && ne.isNotEmpty()) return 0UL
+
+
+        return totalElements * type.byteSize
+    }
+
+    private fun calculateStrides(type: GGMLType, ne: LongArray, maxDims: Int = GGML_MAX_DIMS): ULongArray {
+        val nb = ULongArray(maxDims) { 0uL }
+        if (type.byteSize > 0uL) {
+            nb[0] = type.byteSize
+            var currentNelements = 1L
+            for(d in 0 until maxDims) { // Calculate ne based on actual rank from ne array
+                if (ne[d] == 0L && d > 0) { // typical for dims beyond actual rank if padded with 0
+                     if (d > 0 && ne[d-1] > 0) nb[d] = nb[d-1] * ne[d-1].toULong() else nb[d] = nb[0]
+                     continue
+                }
+                 if (ne[d] == 1L && d > 0 && ne.sliceArray(0 until d).all{it <=1L} ) { // scalar-like up to this dim
+                    currentNelements = 1L // reset for scalar like cases
+                 }
+
+
+                if (d == 0) {
+                    nb[d] = type.byteSize
+                    currentNelements = if(ne[d] > 0) ne[d] else 1L
+                } else {
+                     nb[d] = nb[d-1] * (if (ne[d-1] > 0) ne[d-1].toULong() else 1uL)
+                }
+            }
+        }
+        // Correction for ggml's nb definition where nb[0] is element size, nb[1] is stride for dim1 etc.
+        // The loop above calculates strides such that nb[d] is the stride for dimension d
+        // For contiguous:
+        // nb[0] = type_size
+        // nb[1] = ne[0] * type_size
+        // nb[2] = ne[1] * ne[0] * type_size
+        // nb[3] = ne[2] * ne[1] * ne[0] * type_size
+        // The getElementByteOffset uses: offset += indices[d] * nb[d]
+        // This means nb[d] should be the stride for dimension d.
+        // My loop for nb:
+        // nb[0] = type.byteSize
+        // nb[1] = nb[0] * ne[0]
+        // nb[2] = nb[1] * ne[1]  <-- This is correct for the getElementByteOffset interpretation
+        // nb[d] = nb[d-1] * ne[d-1]
+        // So the loop should be:
+        if (type.byteSize > 0uL) {
+            nb[0] = type.byteSize
+            for (i in 1 until maxDims) {
+                 nb[i] = nb[i-1] * (if (ne[i-1] > 0L) ne[i-1].toULong() else 1uL)
+            }
+        } else {
+            nb.fill(0uL)
+        }
+        return nb
+    }
+
+
+    private fun createTestTensor(
+        name: String,
+        type: GGMLType,
+        dims: LongArray, // Effective dimensions e.g. longArrayOf(10) for 1D, longArrayOf(10,5) for 2D
+        dataOffsetInTestBuffer: ULong,
+        bufferIdToSet: Int = 0 // Assuming buffer 0 is our testBuffer
+    ): GGMLTensor {
+        val tensor = GGMLTensor(type = type)
+        tensor.name = name
+
+        // Pad ne to GGML_MAX_DIMS
+        tensor.ne = LongArray(GGML_MAX_DIMS) { 1L }
+        dims.copyInto(tensor.ne, 0, 0, dims.size.coerceAtMost(GGML_MAX_DIMS))
+
+        tensor.nb = calculateStrides(type, tensor.ne)
+
+        tensor.bufferId = bufferIdToSet
+        tensor.dataOffset = dataOffsetInTestBuffer
+        tensor.data = null // Ensure it uses the shared buffer via accessors
+
+        // Mark it in the graph allocator's map to simulate it being part of a graph
+        // This is important if any tensor method internally tries to look itself up
+        // (Not currently the case for get/set, but good for future-proofing tests)
+        // graphAllocator.tensorUsageMap[tensor] = TensorUsageInfo(ownsMemory = true, bufferId = bufferIdToSet, dataOffset = dataOffsetInTestBuffer, calculatedSize = calculateTensorByteSize(type, tensor.ne))
+
+        return tensor
+    }
+
+    @Test
+    fun testFloatAccess1D() {
+        val dims = longArrayOf(10)
+        val offset = 100uL // Start this tensor at byte offset 100 in the buffer
+        val tensor = createTestTensor("testF32_1D", GGMLType.F32, dims, offset)
+
+        val testData = FloatArray(dims[0].toInt()) { it.toFloat() * 1.1f }
+
+        // Set data
+        for (i in testData.indices) {
+            assertDoesNotThrow("Set F32 1D index $i") {
+                tensor.setFloat(graphAllocator, testData[i], i)
+            }
+        }
+
+        // Get and verify data
+        for (i in testData.indices) {
+            val retrieved = assertDoesNotThrow("Get F32 1D index $i") {
+                tensor.getFloat(graphAllocator, i)
+            }
+            assertEquals(testData[i], retrieved, "F32 1D data mismatch at index $i")
+        }
+    }
+
+    @Test
+    fun testFloatAccess2D() {
+        val dims = longArrayOf(3, 4) // e.g., 3 columns, 4 rows
+        val offset = 200uL
+        val tensor = createTestTensor("testF32_2D", GGMLType.F32, dims, offset)
+
+        // Populate with test data: value = row * 10 + col
+        for (row in 0 until dims[1].toInt()) {
+            for (col in 0 until dims[0].toInt()) {
+                val value = (row * 10 + col).toFloat()
+                 assertDoesNotThrow("Set F32 2D index ($col, $row)") {
+                    tensor.setFloat(graphAllocator, value, col, row)
+                }
+            }
+        }
+
+        // Get and verify
+        for (row in 0 until dims[1].toInt()) {
+            for (col in 0 until dims[0].toInt()) {
+                val expectedValue = (row * 10 + col).toFloat()
+                val retrieved = assertDoesNotThrow("Get F32 2D index ($col, $row)") {
+                    tensor.getFloat(graphAllocator, col, row)
+                }
+                assertEquals(expectedValue, retrieved, "F32 2D data mismatch at ($col, $row)")
+            }
+        }
+    }
+
+    @Test
+    fun testIntAccess1D() {
+        val dims = longArrayOf(8)
+        val offset = 300uL
+        val tensor = createTestTensor("testI32_1D", GGMLType.I32, dims, offset)
+        val testData = IntArray(dims[0].toInt()) { it * 10 }
+
+        testData.forEachIndexed { i, value ->
+            assertDoesNotThrow("Set I32 1D index $i") { tensor.setInt(graphAllocator, value, i) }
+        }
+        testData.forEachIndexed { i, expected ->
+            val retrieved = assertDoesNotThrow("Get I32 1D index $i") { tensor.getInt(graphAllocator, i) }
+            assertEquals(expected, retrieved, "I32 1D data mismatch at index $i")
+        }
+    }
+
+    @Test
+    fun testShortAccess1D() {
+        val dims = longArrayOf(12)
+        val offset = 400uL
+        val tensor = createTestTensor("testI16_1D", GGMLType.I16, dims, offset)
+        val testData = ShortArray(dims[0].toInt()) { (it * 5 - 20).toShort() }
+
+        testData.forEachIndexed { i, value ->
+            assertDoesNotThrow("Set I16 1D index $i") { tensor.setShort(graphAllocator, value, i) }
+        }
+        testData.forEachIndexed { i, expected ->
+            val retrieved = assertDoesNotThrow("Get I16 1D index $i") { tensor.getShort(graphAllocator, i) }
+            assertEquals(expected, retrieved, "I16 1D data mismatch at index $i")
+        }
+    }
+
+    @Test
+    fun testHalfAccess1D() {
+        val dims = longArrayOf(10)
+        val offset = 500uL
+        val tensor = createTestTensor("testF16_1D", GGMLType.F16, dims, offset)
+
+        // Test values including some that might have precision differences
+        val originalFloats = FloatArray(dims[0].toInt()) {
+            when(it) {
+                0 -> 0.0f
+                1 -> 1.0f
+                2 -> -1.0f
+                3 -> 65504.0f // Max F16 normal
+                4 -> 0.000061035156f // Smallest F16 normal
+                5 -> 0.1f
+                6 -> 123.456f
+                else -> (it - 5).toFloat() * 1234.5f
+            }
+        }
+
+        originalFloats.forEachIndexed { i, originalFloat ->
+            val f16Bits = floatToHalf(originalFloat) // Convert original to F16 bits
+            val floatFromF16 = halfToFloat(f16Bits)   // Convert F16 bits back to F32 for comparison
+
+            assertDoesNotThrow("Set F16 1D index $i with value $originalFloat (becomes $floatFromF16)") {
+                 // We set using the original float, setHalf will convert it.
+                tensor.setHalf(graphAllocator, originalFloat, i)
+            }
+
+            val retrievedFloat = assertDoesNotThrow("Get F16 1D index $i") {
+                tensor.getHalf(graphAllocator, i) // getHalf reads F16 bits and converts to F32
+            }
+            // Compare the F32 representation of the stored F16 value
+            assertEquals(floatFromF16, retrievedFloat, "F16 1D data mismatch at index $i. Original: $originalFloat, StoredAsF16ToF32: $floatFromF16, Retrieved: $retrievedFloat")
+        }
+    }
+
+    @Test
+    fun testAccessOutOfBounds_Indices() {
+        val tensorF32 = createTestTensor("f32", GGMLType.F32, longArrayOf(2, 2), 0uL) // 2x2 tensor
+
+        // Too many indices
+        assertFailsWith<IllegalArgumentException>("Should fail with too many indices") {
+            tensorF32.getFloat(graphAllocator, 0, 0, 0)
+        }
+        // Index out of bounds for ne[0]
+        assertFailsWith<IllegalArgumentException>("Should fail with index out of bounds for ne[0]") {
+            tensorF32.getFloat(graphAllocator, 2, 0)
+        }
+        // Index out of bounds for ne[1]
+        assertFailsWith<IllegalArgumentException>("Should fail with index out of bounds for ne[1]") {
+            tensorF32.getFloat(graphAllocator, 0, 2)
+        }
+        // Negative index
+        assertFailsWith<IllegalArgumentException>("Should fail with negative index") {
+            tensorF32.getFloat(graphAllocator, -1, 0)
+        }
+    }
+
+    @Test
+    fun testBufferBoundaryChecks() {
+        val tensorSizeElements = 4
+        val type = GGMLType.F32
+        val elementByteSize = type.byteSize.toInt()
+        val tensorByteSize = tensorSizeElements * elementByteSize // 4 * 4 = 16 bytes
+
+        // Place tensor at an offset such that its end is near the buffer end
+        val offset = (testBuffer.size - tensorByteSize).toULong()
+        val tensor = createTestTensor("boundaryTest", type, longArrayOf(tensorSizeElements.toLong()), offset)
+
+        // Valid access
+        assertDoesNotThrow("Access last element (valid)") {
+            tensor.setFloat(graphAllocator, 1.0f, tensorSizeElements - 1)
+            assertEquals(1.0f, tensor.getFloat(graphAllocator, tensorSizeElements - 1))
+        }
+
+        // Invalid access: trying to read/write one element beyond the allocated tensor space
+        // This should be caught by the accessor's internal check against buffer.size
+        val lastValidFlatByteOffset = offset.toInt() + tensorByteSize - elementByteSize
+        val firstInvalidFlatByteOffset = offset.toInt() + tensorByteSize
+
+        assertTrue(lastValidFlatByteOffset + elementByteSize <= testBuffer.size, "Last valid part should be in buffer")
+        assertTrue(firstInvalidFlatByteOffset > testBuffer.size - elementByteSize || firstInvalidFlatByteOffset >= testBuffer.size, "First invalid part should be outside or at boundary making read impossible")
+
+        assertFailsWith<IndexOutOfBoundsException>("Should fail reading past allocated tensor end / buffer boundary") {
+             // This attempts to read starting at offset + tensorByteSize, which is out of bounds for a full Float.
+            testBuffer.getFloatLe((offset + tensorByteSize.toULong()).toInt())
+        }
+         assertFailsWith<IndexOutOfBoundsException>("Should fail writing past allocated tensor end / buffer boundary") {
+            testBuffer.setFloatLe((offset + tensorByteSize.toULong()).toInt(), 2.0f)
+        }
+
+        // Test accessors for the element just past the end
+        assertFailsWith<IndexOutOfBoundsException>("getFloat should fail reading past tensor's allocated region in buffer") {
+            tensor.getFloat(graphAllocator, tensorSizeElements) // Accessing index 'tensorSizeElements' which is out of bounds for 0-indexed array of this size
+        }
+         assertFailsWith<IndexOutOfBoundsException>("setFloat should fail writing past tensor's allocated region in buffer") {
+            tensor.setFloat(graphAllocator, 3.0f, tensorSizeElements)
+        }
+    }
+}

--- a/src/nativeTest/kotlin/ai/solace/llamakotlin/core/SampleNativeTest.kt
+++ b/src/nativeTest/kotlin/ai/solace/llamakotlin/core/SampleNativeTest.kt
@@ -1,0 +1,11 @@
+package ai.solace.llamakotlin.core
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SampleNativeTest {
+    @Test
+    fun basicTest() {
+        assertTrue(true, "This is a sample test and should pass.")
+    }
+}


### PR DESCRIPTION
This commit introduces unit tests for common activation functions (RELU, GELU, SILU) and the RMSNorm normalization function, covering both F32 and F16 data types.

Key additions to `GGMLComputeOpsTest.kt`:
1.  **Activation Function Tests (RELU, GELU, SILU):**
    *   Added `testComputeReluF32()` and `testComputeReluF16()`.
    *   Added `testComputeGeluF32()` and `testComputeGeluF16()`.
        *   Includes helper `geluApproximation(x: Float)` for expected values.
    *   Added `testComputeSiluF32()` and `testComputeSiluF16()`.
        *   Includes helpers `sigmoid(x: Float)` and `silu(x: Float)`.
    *   Tests create source tensors, call the respective compute function
        from `GGMLComputeOps.kt`, and verify the output tensor's elements
        against expected mathematical results.
    *   F16 tests account for precision differences.

2.  **RMSNorm Function Tests:**
    *   Added `testComputeRMSNormF32()` and `testComputeRMSNormF16()`.
    *   Includes a helper `manualRMSNorm(input: FloatArray, eps: Float)`
        for calculating expected values.
    *   Tests verify the output of `computeRMSNorm` against these manually
        calculated results, with F16 tests considering precision.

3.  **Helper Function for Test Data Retrieval:**
    *   `getTensorDataAsFloatArray` helper is used to extract data from
        result tensors for assertions. (This helper was refined/added during
        the process of implementing these tests).

4.  **`KOTLIN_PORT_CHECKLIST.md` Update:**
    *   Updated Phase 8 (Testing and Validation) under "Test core tensor
        operations" to mark the implementation of tests for these activation
        functions and RMSNorm as complete.

These tests further enhance the reliability and correctness of the core computation functionalities in the Kotlin port.

