### PR TITLE
Add SoftMax compute operation

### DIFF
--- a/src/nativeMain/kotlin/ai/solace/llamakotlin/core/GGMLComputeOps.kt
+++ b/src/nativeMain/kotlin/ai/solace/llamakotlin/core/GGMLComputeOps.kt
@@ -944,6 +944,19 @@ fun computeSilu(graphAllocator: GGMLGraphAllocator, a: GGMLTensor): GGMLTensor {
     return dst
 }
 
+/**
+ * Computes the SoftMax of tensor [a].
+ * Applies the operation along the first dimension of each row, producing a tensor of the same shape and type.
+ */
+fun computeSoftMax(graphAllocator: GGMLGraphAllocator, a: GGMLTensor): GGMLTensor {
+    val dst = GGMLTensor(type = a.type)
+    dst.ne = a.ne.copyOf(); dst.nb = calculateContiguousStrides(dst.ne, dst.type, dst.rank())
+    val tempGraph = GGMLCGraph(size = 1, nodes = arrayOf(dst), grads = arrayOfNulls(1), leafs = arrayOfNulls(1), allocator = graphAllocator)
+    graphAllocator.allocateGraph(tempGraph)
+    computeSoftMax(graphAllocator, graphAllocator.context, a, dst)
+    return dst
+}
+
 fun computeRMSNorm(graphAllocator: GGMLGraphAllocator, a: GGMLTensor, eps: Float): GGMLTensor {
     val dst = GGMLTensor(type = a.type)
     dst.ne = a.ne.copyOf(); dst.nb = calculateContiguousStrides(dst.ne, dst.type, dst.rank())
@@ -1649,6 +1662,80 @@ fun computeSilu(graphAllocator: GGMLGraphAllocator, @Suppress("unused") context:
             dst.setHalf(graphAllocator, v * sigmoid(v), *ind)
         }
         else -> throw NotImplementedError("computeSilu not implemented for type ${a.type}")
+    }
+}
+
+fun computeSoftMax(graphAllocator: GGMLGraphAllocator, @Suppress("unused") context: GGMLContext, a: GGMLTensor, dst: GGMLTensor) {
+    for (i in 0 until GGML_MAX_DIMS) {
+        if (a.ne[i] != dst.ne[i]) throw IllegalArgumentException("Result tensor dimensions must match input dimensions")
+    }
+    if (dst.type != a.type) throw IllegalArgumentException("Result tensor type must match input type")
+
+    val nCols = a.ne[0].toInt()
+    val nRows = (a.numElements() / a.ne[0]).toInt()
+    val rank = a.rank()
+    val baseIndices = IntArray(rank)
+
+    when (a.type) {
+        GGMLType.F32 -> {
+            for (row in 0 until nRows) {
+                var tmp = row
+                for (d in 1 until rank) {
+                    val dimSize = a.ne[d].toInt()
+                    baseIndices[d] = tmp % dimSize
+                    tmp /= dimSize
+                }
+                var maxVal = Float.NEGATIVE_INFINITY
+                for (col in 0 until nCols) {
+                    baseIndices[0] = col
+                    val v = a.getFloat(graphAllocator, *baseIndices)
+                    if (v > maxVal) maxVal = v
+                }
+                var sum = 0.0f
+                for (col in 0 until nCols) {
+                    baseIndices[0] = col
+                    val e = exp(a.getFloat(graphAllocator, *baseIndices) - maxVal)
+                    dst.setFloat(graphAllocator, e, *baseIndices)
+                    sum += e
+                }
+                val invSum = 1.0f / sum
+                for (col in 0 until nCols) {
+                    baseIndices[0] = col
+                    val v = dst.getFloat(graphAllocator, *baseIndices) * invSum
+                    dst.setFloat(graphAllocator, v, *baseIndices)
+                }
+            }
+        }
+        GGMLType.F16 -> {
+            for (row in 0 until nRows) {
+                var tmp = row
+                for (d in 1 until rank) {
+                    val dimSize = a.ne[d].toInt()
+                    baseIndices[d] = tmp % dimSize
+                    tmp /= dimSize
+                }
+                var maxVal = Float.NEGATIVE_INFINITY
+                for (col in 0 until nCols) {
+                    baseIndices[0] = col
+                    val v = a.getHalf(graphAllocator, *baseIndices)
+                    if (v > maxVal) maxVal = v
+                }
+                var sum = 0.0f
+                for (col in 0 until nCols) {
+                    baseIndices[0] = col
+                    val e = exp(a.getHalf(graphAllocator, *baseIndices) - maxVal)
+                    dst.setHalf(graphAllocator, e, *baseIndices)
+                    sum += e
+                }
+                val invSum = 1.0f / sum
+                for (col in 0 until nCols) {
+                    baseIndices[0] = col
+                    val v = dst.getHalf(graphAllocator, *baseIndices) * invSum
+                    dst.setHalf(graphAllocator, v, *baseIndices)
+                }
+            }
+        }
+        else -> throw NotImplementedError("computeSoftMax not implemented for type ${a.type}")
     }
 }
 
@@ -2641,6 +2728,7 @@ object GGMLComputeOps {
             GGMLOp.RELU -> computeRelu(graphAllocator, node)
             GGMLOp.GELU -> computeGelu(graphAllocator, node)
             GGMLOp.SILU -> computeSilu(graphAllocator, node)
+            GGMLOp.SOFT_MAX -> computeSoftMax(graphAllocator, node)
             GGMLOp.RMS_NORM -> computeRmsNorm(graphAllocator, node)
             GGMLOp.MUL_MAT -> computeMulMat(graphAllocator, node)
             GGMLOp.SUM -> computeSum(graphAllocator, node)
@@ -2736,6 +2824,12 @@ object GGMLComputeOps {
         val src = node.src[0] ?: throw IllegalArgumentException("SILU operation requires source tensor")
     val context = graphAllocator.context
     computeSilu(graphAllocator, context, src, node)
+    }
+
+    private fun computeSoftMax(graphAllocator: GGMLGraphAllocator, node: GGMLTensor) {
+        val src = node.src[0] ?: throw IllegalArgumentException("SOFT_MAX operation requires source tensor")
+    val context = graphAllocator.context
+    computeSoftMax(graphAllocator, context, src, node)
     }
 
     private fun computeRmsNorm(graphAllocator: GGMLGraphAllocator, node: GGMLTensor) {

--- a/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLComputeOpsDestinationTest.kt
+++ b/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLComputeOpsDestinationTest.kt
@@ -1,5 +1,6 @@
 package ai.solace.llamakotlin.core
 
+import kotlin.math.exp
 import kotlin.test.*
 
 /**
@@ -190,6 +191,34 @@ class GGMLComputeOpsDestinationTest {
             val expected = if (testValues[i] > 0.0f) testValues[i] else 0.0f
             val actual = dst.getFloat(graphAllocator, i)
             assertEquals(expected, actual, "RELU result mismatch at index $i")
+        }
+    }
+
+    @Test
+    fun testComputeSoftMaxWithDestination() {
+        val context = GGMLContext()
+        var currentOffset = 0uL
+        val dims = longArrayOf(4)
+        val size = calculateTensorByteSize(GGMLType.F32, dims)
+
+        val src = createAndInitTensor("softmax_src", GGMLType.F32, dims, currentOffset)
+        val testValues = floatArrayOf(1f, 2f, 3f, 4f)
+        for (i in testValues.indices) {
+            src.setFloat(graphAllocator, testValues[i], i)
+        }
+        currentOffset += size
+
+        val dst = createAndInitTensor("softmax_dst", GGMLType.F32, dims, currentOffset)
+
+        computeSoftMax(graphAllocator, context, src, dst)
+
+        val max = testValues.maxOrNull()!!
+        val expVals = testValues.map { exp(it - max) }
+        val sum = expVals.sum()
+        for (i in testValues.indices) {
+            val expected = (expVals[i] / sum).toFloat()
+            val actual = dst.getFloat(graphAllocator, i)
+            assertEquals(expected, actual, 1e-5f, "SoftMax result mismatch at index $i")
         }
     }
 

--- a/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLComputeOpsTest.kt
+++ b/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLComputeOpsTest.kt
@@ -645,6 +645,52 @@ class GGMLComputeOpsTest {
         }
     }
 
+    // --- SOFT_MAX Tests ---
+    @Test
+    fun testComputeSoftMaxF32() {
+        val srcNe = longArrayOf(4)
+        val srcData = floatArrayOf(1f, 2f, 3f, 4f)
+        val srcTensor = createAndInitTensor("softmax_f32_src", GGMLType.F32, srcNe, dataOffset = 0uL)
+        for (i in srcData.indices) srcTensor.setFloat(graphAllocator, srcData[i], i)
+
+        val resultTensor = computeSoftMax(graphAllocator, srcTensor)
+
+        assertEquals(GGMLType.F32, resultTensor.type)
+        assertTrue(srcTensor.ne.contentEquals(resultTensor.ne), "Dimensions should match for SoftMax F32")
+
+        val max = srcData.maxOrNull()!!
+        val expVals = srcData.map { exp(it - max).toFloat() }
+        val sum = expVals.sum()
+        val expected = expVals.map { it / sum }.toFloatArray()
+        val resultData = getTensorDataAsFloatArray(resultTensor, graphAllocator)
+        for (i in expected.indices) {
+            assertEquals(expected[i], resultData[i], 1e-5f, "SoftMax F32 output mismatch at index $i")
+        }
+    }
+
+    @Test
+    fun testComputeSoftMaxF16() {
+        val srcNe = longArrayOf(4)
+        val srcDataF32 = floatArrayOf(1f, 2f, 3f, 4f)
+        val srcTensor = createAndInitTensor("softmax_f16_src", GGMLType.F16, srcNe, dataOffset = 0uL)
+        for (i in srcDataF32.indices) srcTensor.setHalf(graphAllocator, srcDataF32[i], i)
+
+        val resultTensor = computeSoftMax(graphAllocator, srcTensor)
+
+        assertEquals(GGMLType.F16, resultTensor.type)
+        assertTrue(srcTensor.ne.contentEquals(resultTensor.ne), "Dimensions should match for SoftMax F16")
+
+        val max = srcDataF32.maxOrNull()!!
+        val expVals = srcDataF32.map { exp(it - max).toFloat() }
+        val sum = expVals.sum()
+        val expectedF32 = expVals.map { it / sum }.toFloatArray()
+        val resultDataF16AsF32 = getTensorDataAsFloatArray(resultTensor, graphAllocator)
+        for (i in expectedF32.indices) {
+            assertEquals(halfToFloat(floatToHalf(expectedF32[i])), resultDataF16AsF32[i], 0.001f,
+                "SoftMax F16 output mismatch at index $i")
+        }
+    }
+
     // --- RMS_NORM Tests ---
     @Test
     fun testComputeRMSNormF32() {


### PR DESCRIPTION
## Summary
- implement SoftMax tensor operation for F32 and F16
- integrate SoftMax into compute graph dispatch
- cover SoftMax with unit tests and destination-based tests

## Testing
- `./gradlew allTests`

------
https://chatgpt.com/codex/tasks/task_e_68b957a325308333a09c8aa5857f9472