### PR TITLE
Add K-Quant Q3_K and Q5_K accuracy tests

### DIFF
--- a/GGML_TESTING_SUMMARY.md
+++ b/GGML_TESTING_SUMMARY.md
@@ -130,7 +130,12 @@ This document provides a comprehensive summary of the testing infrastructure imp
 ### 🔄 Remaining Work (Future)
 - [ ] End-to-end model loading and inference tests
 - [ ] Comparison with original C++ implementation outputs
-- [ ] Support for additional quantization types (Q2_K, Q3_K, etc.)
+- [~] Support for additional quantization types
+  - [x] Q2_K
+  - [x] Q3_K
+  - [x] Q4_K
+  - [x] Q5_K
+  - [ ] Q6_K
 - [ ] Extended model compatibility validation
 
 ## 🎉 Achievement Highlights

--- a/KOTLIN_PORT_CHECKLIST.md
+++ b/KOTLIN_PORT_CHECKLIST.md
@@ -247,10 +247,15 @@ This checklist is based on the current state of the Kotlin Native port of llama.
     - [x] Added synthetic data generation matching upstream test-quantize-fns.cpp patterns.
     - [x] Added random data, edge case, and cross-quantization validation.
     - [x] Added dot product accuracy testing for quantized operations.
-    - [ ] Test accuracy for other future quantization types as they are implemented (e.g., Q2_K, Q3_K, Q5_K, Q6_K).
-  - [x] Test `GGMLDynTensorAllocator` (dynamic memory allocation within a buffer).
-  - [x] Test `GGMLGraphAllocator` (graph-level memory planning: reserve, inplace allocation, freeing).
-  - [x] Test `GGMLTensor` data accessors (low-level read/write for F32, I32, I16, F16).
+    - [~] Test accuracy for other future quantization types as they are implemented.
+      - [x] Q2_K
+      - [x] Q3_K
+      - [x] Q4_K
+      - [x] Q5_K
+      - [ ] Q6_K
+    - [x] Test `GGMLDynTensorAllocator` (dynamic memory allocation within a buffer).
+    - [x] Test `GGMLGraphAllocator` (graph-level memory planning: reserve, inplace allocation, freeing).
+    - [x] Test `GGMLTensor` data accessors (low-level read/write for F32, I32, I16, F16).
 
 - [x] Implement Integration Tests
   - [x] Test end-to-end computation graph operations and complex operation chains.

--- a/KOTLIN_PORT_STATUS.md
+++ b/KOTLIN_PORT_STATUS.md
@@ -29,6 +29,7 @@ The project has made substantial progress across multiple development phases. He
      - BitNet 1.58 ternary quantization implementation
      - Direct quantized-to-quantized operations (Q×Q) avoiding expensive dequantization
      - Symmetric F32×Q_type optimizations providing 2-3x speedups
+     - K-Quant family (Q2_K, Q3_K, Q4_K, Q5_K, Q6_K, Q8_K) with accuracy tests for Q2_K, Q3_K, Q4_K, Q5_K, and Q8_K
    - **Automatic differentiation** with backward pass for all core operations
 
 3. **✅ Phase 6 - Model Loading and File Format Support**: Largely Complete

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a **Kotlin/Native implementation** of llama.cpp, designed to bring the p
 - **CPU and Apple Metal backends** for optimal performance on supported hardware
 - **Idiomatic Kotlin API** while maintaining compatibility with original concepts
 - **Memory-efficient tensor operations** adapted for Kotlin/Native's memory model
-- **Comprehensive quantization support** (Q8_0, Q4_0, Q4_1, with K-Quant types in progress)
+- **Comprehensive quantization support** (Q8_0, Q4_0, Q4_1, BitNet 1.58, and K-Quant types Q2_K, Q3_K, Q4_K, Q5_K, Q8_K; Q6_K in progress)
 - **Automatic differentiation** for training and fine-tuning capabilities
 
 ## Current Status - Phase 3-4 (Advanced Core Implementation & Backend Development)

--- a/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLKQuantAccuracyTest.kt
+++ b/src/nativeTest/kotlin/ai/solace/llamakotlin/core/GGMLKQuantAccuracyTest.kt
@@ -159,6 +159,44 @@ class GGMLKQuantAccuracyTest {
     }
 
     @Test
+    fun testQ3_KAccuracy() {
+        val numElements = QK_K * 2 // Test with 2 blocks
+        val originalF32Data = FloatArray(numElements) { i ->
+            when (i / QK_K) {
+                0 -> (i % QK_K).toFloat() / QK_K.toFloat() * 3.0f - 1.5f // Block 1: -1.5 to 1.5
+                else -> if ((i % 3) == 0) 0.75f else -0.75f // Block 2: alternating values
+            }
+        }
+
+        val dims = longArrayOf(numElements.toLong())
+        val f32SrcTensor = createAndPopulateF32Tensor("f32Src_Q3K_Test", dims, originalF32Data, dataOffset = 0uL)
+
+        // Quantize to Q3_K
+        val q3kTensor = quantizeTensor(graphAllocator, f32SrcTensor, GGMLType.Q3_K)
+        assertEquals(GGMLType.Q3_K, q3kTensor.type)
+        assertTrue(q3kTensor.ne.contentEquals(f32SrcTensor.ne))
+        assertNotNull(q3kTensor.data)
+        assertTrue(q3kTensor.data is ByteArray)
+
+        // Dequantize back to F32
+        val f32DequantizedTensor = dequantizeTensor(graphAllocator, q3kTensor)
+        assertEquals(GGMLType.F32, f32DequantizedTensor.type)
+        assertNotNull(f32DequantizedTensor.data)
+        assertTrue(f32DequantizedTensor.data is FloatArray)
+
+        val dequantizedF32Data = getTensorDataAsFloatArray(f32DequantizedTensor, graphAllocator)
+        assertEquals(originalF32Data.size, dequantizedF32Data.size)
+
+        val mse = calculateMeanSquaredError(originalF32Data, dequantizedF32Data)
+        val mseThreshold = 0.08 // Q3_K precision expected between Q2_K and Q4_K
+        assertTrue(mse < mseThreshold, "Q3_K MSE $mse too high (threshold $mseThreshold)")
+
+        val mad = calculateMeanAbsoluteDifference(originalF32Data, dequantizedF32Data)
+        val madThreshold = 0.25
+        assertTrue(mad < madThreshold, "Q3_K Mean Absolute Difference $mad too high (threshold $madThreshold)")
+    }
+
+    @Test
     fun testQ4_KAccuracy() {
         val numElements = QK_K * 2 // Test with 2 blocks
         val originalF32Data = FloatArray(numElements) { i ->
@@ -195,6 +233,44 @@ class GGMLKQuantAccuracyTest {
         val mad = calculateMeanAbsoluteDifference(originalF32Data, dequantizedF32Data)
         val madThreshold = 0.2
         assertTrue(mad < madThreshold, "Q4_K Mean Absolute Difference $mad too high (threshold $madThreshold)")
+    }
+
+    @Test
+    fun testQ5_KAccuracy() {
+        val numElements = QK_K * 2 // Test with 2 blocks
+        val originalF32Data = FloatArray(numElements) { i ->
+            when (i / QK_K) {
+                0 -> (i % QK_K).toFloat() / QK_K.toFloat() * 4.0f - 2.0f // Block 1: -2.0 to 2.0
+                else -> if ((i % QK_K) % 32 < 16) 1.25f else -1.25f // Block 2: alternating blocks of 1.25/-1.25
+            }
+        }
+
+        val dims = longArrayOf(numElements.toLong())
+        val f32SrcTensor = createAndPopulateF32Tensor("f32Src_Q5K_Test", dims, originalF32Data, dataOffset = 0uL)
+
+        // Quantize to Q5_K
+        val q5kTensor = quantizeTensor(graphAllocator, f32SrcTensor, GGMLType.Q5_K)
+        assertEquals(GGMLType.Q5_K, q5kTensor.type)
+        assertTrue(q5kTensor.ne.contentEquals(f32SrcTensor.ne))
+        assertNotNull(q5kTensor.data)
+        assertTrue(q5kTensor.data is ByteArray)
+
+        // Dequantize back to F32
+        val f32DequantizedTensor = dequantizeTensor(graphAllocator, q5kTensor)
+        assertEquals(GGMLType.F32, f32DequantizedTensor.type)
+        assertNotNull(f32DequantizedTensor.data)
+        assertTrue(f32DequantizedTensor.data is FloatArray)
+
+        val dequantizedF32Data = getTensorDataAsFloatArray(f32DequantizedTensor, graphAllocator)
+        assertEquals(originalF32Data.size, dequantizedF32Data.size)
+
+        val mse = calculateMeanSquaredError(originalF32Data, dequantizedF32Data)
+        val mseThreshold = 0.03 // Q5_K has higher precision than Q4_K
+        assertTrue(mse < mseThreshold, "Q5_K MSE $mse too high (threshold $mseThreshold)")
+
+        val mad = calculateMeanAbsoluteDifference(originalF32Data, dequantizedF32Data)
+        val madThreshold = 0.15
+        assertTrue(mad < madThreshold, "Q5_K Mean Absolute Difference $mad too high (threshold $madThreshold)")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add accuracy tests for Q3_K and Q5_K quantization formats
- document K-Quant test coverage in checklists, status, and testing summary
- note expanded quantization support in README

## Testing
- `./gradlew allTests`

------
https://chatgpt.com/codex/tasks/task_e_68c6a09472e48333a761b8c26673c48c